### PR TITLE
拆分用于生成访问 Kubernetes 集群的 Config 对象逻辑 / 单元测试

### DIFF
--- a/bcs-app/backend/resources/client.py
+++ b/bcs-app/backend/resources/client.py
@@ -12,15 +12,20 @@
 # specific language governing permissions and limitations under the License.
 #
 import logging
-
 from functools import lru_cache
+from typing import Dict, Any
 
 from django.utils.translation import ugettext_lazy as _
+from django.conf import settings
+from kubernetes.client.configuration import Configuration
 from kubernetes import client
 
 from backend.utils.error_codes import error_codes
+from backend.components.utils import http_get
 from backend.components.bcs import k8s
 from backend.components.bcs import k8s_client
+from backend.components import paas_cc
+from backend.utils import exceptions
 
 logger = logging.getLogger(__name__)
 
@@ -52,3 +57,112 @@ class K8SClient:
         self.project_id = project_id
         self.cluster_id = cluster_id
         self.client = k8s.K8SClient(access_token, project_id, cluster_id, None)
+
+
+class BcsKubeAddressesProvider:
+    """提供访问集群的各 API 访问地址，包括：
+
+    - 查询集群信息的 BCS API 地址
+    - 连接集群 apiserver 的基础地址
+    """
+
+    def __init__(self, access_token: str, project_id: str, cluster_id: str):
+        self.access_token = access_token
+        self.project_id = project_id
+        self.cluster_id = cluster_id
+
+    def _query_stag_name(self) -> str:
+        """通过 PaaS-CC 服务查询获取集群 stag 名称，stag 名称可用于拼装 API 地址
+
+        :raises ComponentError: 从 PaaS-CC 返回了错误响应
+        """
+        # Cache
+        if hasattr(self, '_stag_name'):
+            return self._stag_name
+
+        cluster = paas_cc.get_cluster(self.access_token, self.project_id, self.cluster_id)
+        # TODO: 封装异常，不使用模糊的 ComponentError
+        if cluster.get('code') != 0:
+            raise exceptions.ComponentError(cluster.get('message'))
+
+        environment = cluster['data']['environment']
+        self._stag_name = settings.BCS_API_ENV[environment]
+        return self._stag_name
+
+    def get_api_base_url(self) -> str:
+        """获取 BCS API 服务基础 URL 地址"""
+        stag_name = self._query_stag_name()
+        return f"{settings.BCS_API_PRE_URL}/{stag_name}"
+
+    def get_clusters_base_url(self) -> str:
+        """获取通过 BCS API 查询集群信息的基础 URL 地址"""
+        api_base_url = self.get_api_base_url()
+        return f"{api_base_url}/rest/clusters"
+
+    def get_kube_apiservers_host(self) -> str:
+        """获取 Kubernetes 集群 apiserver 基础地址"""
+        stag_name = self._query_stag_name()
+        return settings.BCS_SERVER_HOST[stag_name]
+
+
+class BcsKubeConfigurationService:
+    """生成用于连接 Kubernetes 集群的配置对象 Configuration
+    通过查询 BCS 服务，获取集群 apiserver 地址与 token 等信息
+
+    :param access_token: 用户 token，请求 API 时使用
+    :param project_id: 项目 ID
+    :param cluster_id: 集群 ID
+    """
+
+    def __init__(self, access_token: str, project_id: str, cluster_id: str):
+        self.access_token = access_token
+        self.project_id = project_id
+        self.cluster_id = cluster_id
+        self.addresses = BcsKubeAddressesProvider(access_token, project_id, cluster_id)
+
+    def make_configuration(self) -> Configuration:
+        """生成 Kubernetes SDK 所需的 Configuration 对象"""
+        config = client.Configuration()
+        config.verify_ssl = False
+
+        # Get credentials
+        credentials = self.get_client_credentials()
+        config.host = '{}{}'.format(
+            self.addresses.get_kube_apiservers_host(), credentials['server_address_path']
+        ).rstrip("/")
+        config.api_key = {"authorization": f"Bearer {credentials['user_token']}"}
+        return config
+
+    def get_client_credentials(self) -> Dict[str, Any]:
+        """获取访问集群 apiserver 所需的鉴权信息，比如证书、user_token、server_address_path 等"""
+        bke_cluster_id = self._get_bke_cluster_id()
+        _query_credentials_url = f"{self.addresses.get_clusters_base_url()}/{bke_cluster_id}/client_credentials"
+
+        result = http_get(
+            _query_credentials_url,
+            params={"access_token": self.access_token},
+            raise_for_status=False,
+            headers=self.bcs_request_headers,
+        )
+        return result
+
+    def _get_bke_cluster_id(self) -> str:
+        """查询集群在 BKE 服务的 ID"""
+        _query_cluster_url = f"{self.addresses.get_clusters_base_url()}/bcs/query_by_id/"
+        result = http_get(
+            _query_cluster_url,
+            params={
+                "access_token": self.access_token,
+                "project_id": self.project_id,
+                "cluster_id": self.cluster_id,
+            },
+            raise_for_status=False,
+            headers=self.bcs_request_headers,
+        )
+        return result['id']
+
+    @property
+    def bcs_request_headers(self):
+        """用户请求 BCS 接口的 headers"""
+        auth_token = getattr(settings, "BCS_AUTH_TOKEN", "")
+        return {"Authorization": auth_token, "Content-Type": "application/json"}

--- a/bcs-app/backend/tests/resources/conftest.py
+++ b/bcs-app/backend/tests/resources/conftest.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+import pytest
+from kubernetes import client
+
+from backend.tests.testing_utils.base import generate_random_string
+
+# 由项目 dev_utils 启动的测试用 apiserver 服务
+TESTING_API_SERVER_URL = 'http://localhost:28180'
+
+
+@pytest.fixture
+def cluster_id():
+    """生成一个随机集群 ID"""
+    return generate_random_string(8)
+
+
+@pytest.fixture
+def project_id():
+    """生成一个随机项目 ID"""
+    return generate_random_string(8)
+
+
+@pytest.fixture
+def testing_kubernetes_apiclient():
+    """返回连接单元测试 apiserver 的 ApiClient 实例"""
+    configuration = client.Configuration()
+    configuration.verify_ssl = False
+    configuration.host = TESTING_API_SERVER_URL
+    return client.ApiClient(configuration)

--- a/bcs-app/backend/tests/resources/test_client.py
+++ b/bcs-app/backend/tests/resources/test_client.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""Test codes for backend.resources module"""
+import pytest
+from unittest import mock
+from backend.resources.client import (
+    BcsKubeAddressesProvider,
+    BcsKubeConfigurationService,
+)
+from backend.utils.exceptions import ComponentError
+
+
+@pytest.fixture(autouse=True)
+def setup_settings(settings):
+    """Setup required settings for unittests"""
+    settings.BCS_API_ENV = {'stag': 'my_stag', 'prod': 'my_prod'}
+    settings.BCS_SERVER_HOST = {
+        'my_stag': 'https://my-stag-bcs-server.example.com',
+        'my_prod': 'https://my-prod-bcs-server.example.com',
+    }
+    settings.BCS_API_PRE_URL = 'https://bcs-api.example.com'
+
+
+fake_cc_get_cluster_result_ok = {'code': 0, 'result': True, 'data': {'environment': 'stag'}}
+fake_cc_get_cluster_result_failed = {'code': 100, 'result': False}
+
+
+class TestBcsKubeAddressesProvider:
+    @mock.patch('backend.resources.client.paas_cc.get_cluster', return_value=fake_cc_get_cluster_result_ok)
+    def test_normal(self, project_id, cluster_id):
+        addresses = BcsKubeAddressesProvider('token', project_id, cluster_id)
+        stag_name = addresses._query_stag_name()
+        assert stag_name == 'my_stag'
+        assert addresses.get_api_base_url() == 'https://bcs-api.example.com/my_stag'
+        assert addresses.get_clusters_base_url() == 'https://bcs-api.example.com/my_stag/rest/clusters'
+        assert addresses.get_kube_apiservers_host() == 'https://my-stag-bcs-server.example.com'
+
+    @mock.patch('backend.resources.client.paas_cc.get_cluster', return_value=fake_cc_get_cluster_result_failed)
+    def test_failed(self, project_id, cluster_id):
+        addresses = BcsKubeAddressesProvider('token', project_id, cluster_id)
+        with pytest.raises(ComponentError):
+            assert addresses.get_api_base_url()
+
+
+class TestBcsKubeConfigurationService:
+    @mock.patch('backend.resources.client.paas_cc.get_cluster', return_value=fake_cc_get_cluster_result_ok)
+    def test_make_configuration(self, project_id, cluster_id):
+        config_service = BcsKubeConfigurationService('token', project_id, cluster_id)
+
+        with mock.patch('backend.resources.client.http_get') as http_get_mocker:
+            http_get_mocker.side_effect = [
+                {'id': '10000'},  # Query BKE Server ID
+                {'server_address_path': '/foo', 'user_token': 'foo-token'},  # Query credentials
+            ]
+            config = config_service.make_configuration()
+
+            assert http_get_mocker.call_count == 2
+            assert (
+                http_get_mocker.call_args[0][0]
+                == 'https://bcs-api.example.com/my_stag/rest/clusters/10000/client_credentials'
+            )
+            assert config.host == 'https://my-stag-bcs-server.example.com/foo'
+            assert config.api_key['authorization'] == 'Bearer foo-token'

--- a/bcs-app/backend/tests/resources/test_resources.py
+++ b/bcs-app/backend/tests/resources/test_resources.py
@@ -11,40 +11,11 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 #
-from _pytest.config import Config
-import pytest
-from pprint import pprint
 from unittest import mock
+
+from .conftest import TESTING_API_SERVER_URL
 from backend.components.bcs.k8s import K8SClient
 from backend.components.bcs.resources.namespace import Namespace
-
-from backend.tests.testing_utils.base import generate_random_string
-
-from kubernetes import client
-
-# 由项目 dev_utils 启动的测试用 apiserver 服务
-TESTING_API_SERVER_URL = 'http://localhost:28180'
-
-
-@pytest.fixture
-def cluster_id():
-    """生成一个随机集群 ID"""
-    return generate_random_string(8)
-
-
-@pytest.fixture
-def project_id():
-    """生成一个随机项目 ID"""
-    return generate_random_string(8)
-
-
-@pytest.fixture
-def testing_kubernetes_apiclient():
-    """返回连接单元测试 apiserver 的 ApiClient 实例"""
-    configuration = client.Configuration()
-    configuration.verify_ssl = False
-    configuration.host = TESTING_API_SERVER_URL
-    return client.ApiClient(configuration)
 
 
 class TestNamespace:


### PR DESCRIPTION
- 拆分用于生成访问 Kubernetes 集群的 Config 对象逻辑
- 补充配置生成单元测试
