### PR TITLE
fix: CacheDecoder object is not callable

### DIFF
--- a/bcs-app/backend/bcs_k8s/app/models.py
+++ b/bcs-app/backend/bcs_k8s/app/models.py
@@ -22,15 +22,13 @@ from jsonfield import JSONField
 from picklefield.fields import PickledObjectField
 from rest_framework.exceptions import ValidationError
 
-from backend.bcs_k8s.helm.models import Chart, ChartRelease
-from backend.bcs_k8s.helm.constants import RELEASE_VERSION_PREFIX
 from backend.activity_log import client
 from backend.activity_log.client import get_log_client_by_activity_log_id
 from backend.apps.whitelist_bk import enable_helm_v3
 from backend.bcs_k8s import utils as bcs_helm_utils
 from backend.bcs_k8s.app.utils import get_cc_app_id
 from backend.bcs_k8s.diff.revision import AppRevisionDiffer
-from backend.bcs_k8s.helm.constants import DEFAULT_VALUES_FILE_NAME, KEEP_TEMPLATE_UNCHANGED
+from backend.bcs_k8s.helm.constants import DEFAULT_VALUES_FILE_NAME, KEEP_TEMPLATE_UNCHANGED, RELEASE_VERSION_PREFIX
 from backend.bcs_k8s.helm.models import Chart, ChartRelease
 from backend.bcs_k8s.kubehelm import exceptions as helm_exceptions
 
@@ -281,7 +279,10 @@ class App(models.Model):
             resource_id=self.id,
             extra=extra,
             description="Helm App[{app_name}:{app_id}] upgrade, cluster[{cluster_id}], namespace[{namespace}]".format(
-                app_id=self.id, app_name=self.name, namespace=self.namespace, cluster_id=self.cluster_id,
+                app_id=self.id,
+                app_name=self.name,
+                namespace=self.namespace,
+                cluster_id=self.cluster_id,
             ),
         )
         logger_client.log(activity_status="busy")
@@ -339,7 +340,7 @@ class App(models.Model):
         valuefile_name=DEFAULT_VALUES_FILE_NAME,
         **kwargs,
     ):
-        from .tasks import upgrade_app, sync_or_async
+        from .tasks import sync_or_async, upgrade_app
 
         # if self.transitioning_on:
         #    raise ValidationError("helm app is on transitioning, please try a later.")
@@ -431,7 +432,12 @@ class App(models.Model):
 
     def record_rollback_app(self, username, release_id, access_token):
         # operation record
-        extra = json.dumps(dict(access_token=access_token, release_id=release_id,))
+        extra = json.dumps(
+            dict(
+                access_token=access_token,
+                release_id=release_id,
+            )
+        )
         logger_client = client.UserActivityLogClient(
             project_id=self.project_id,
             user=username,
@@ -441,7 +447,10 @@ class App(models.Model):
             resource_id=self.id,
             extra=extra,
             description="Helm App[{app_name}:{app_id}] rollback, cluster[{cluster_id}], namespace[{namespace}]".format(
-                app_id=self.id, app_name=self.name, namespace=self.namespace, cluster_id=self.cluster_id,
+                app_id=self.id,
+                app_name=self.name,
+                namespace=self.namespace,
+                cluster_id=self.cluster_id,
             ),
         )
         logger_client.log(activity_status="busy")
@@ -455,13 +464,22 @@ class App(models.Model):
 
         self.reset_transitioning("rollback")
         sync_or_async(rollback_app)(
-            kwargs={"app_id": self.id, "access_token": access_token, "username": username, "release_id": release_id,}
+            kwargs={
+                "app_id": self.id,
+                "access_token": access_token,
+                "username": username,
+                "release_id": release_id,
+            }
         )
         return self
 
     def rollback_app_task(self, username, release_id, access_token):
         # simple make a copy of release, set release type, then install
-        log_client = self.record_rollback_app(username=username, access_token=access_token, release_id=release_id,)
+        log_client = self.record_rollback_app(
+            username=username,
+            access_token=access_token,
+            release_id=release_id,
+        )
         try:
             release = ChartRelease.objects.get(id=release_id)
             app_deployer = AppDeployer(app=self, access_token=access_token)
@@ -508,7 +526,12 @@ class App(models.Model):
     def get_upgrade_version_selections(self):
         options = list(self.chart.versions.values("id", "version").order_by("-created"))
         release = self.release
-        current_version = [{"id": KEEP_TEMPLATE_UNCHANGED, "version": f"{RELEASE_VERSION_PREFIX} {release.version}",}]
+        current_version = [
+            {
+                "id": KEEP_TEMPLATE_UNCHANGED,
+                "version": f"{RELEASE_VERSION_PREFIX} {release.version}",
+            }
+        ]
         options = current_version + options
         return options
 
@@ -523,7 +546,11 @@ class App(models.Model):
 
     def record_destroy(self, username, access_token):
         # operation record
-        extra = json.dumps(dict(access_token=access_token,))
+        extra = json.dumps(
+            dict(
+                access_token=access_token,
+            )
+        )
         logger_client = client.UserActivityLogClient(
             project_id=self.project_id,
             user=username,
@@ -533,7 +560,10 @@ class App(models.Model):
             resource_id=self.id,
             extra=extra,
             description="Helm App[{app_name}:{app_id}] delete, cluster[{cluster_id}], namespace[{namespace}]".format(
-                app_id=self.id, app_name=self.name, namespace=self.namespace, cluster_id=self.cluster_id,
+                app_id=self.id,
+                app_name=self.name,
+                namespace=self.namespace,
+                cluster_id=self.cluster_id,
             ),
         )
         logger_client.log(activity_status="busy")
@@ -547,7 +577,11 @@ class App(models.Model):
 
         self.reset_transitioning("delete")
         sync_or_async(destroy_app)(
-            kwargs={"app_id": self.id, "access_token": access_token, "username": username,}
+            kwargs={
+                "app_id": self.id,
+                "access_token": access_token,
+                "username": username,
+            }
         )
 
     def destroy_app_task(self, username, access_token):

--- a/bcs-app/backend/dashboard/custom_object/views.py
+++ b/bcs-app/backend/dashboard/custom_object/views.py
@@ -16,7 +16,8 @@ from rest_framework import viewsets
 from rest_framework.renderers import BrowsableAPIRenderer
 from rest_framework.response import Response
 
-from backend.resources.custom_object import CustomResourceDefinition, get_custom_object_client_by_crd
+from backend.resources.custom_object import CustomResourceDefinition, get_cobj_client_by_crd
+from backend.resources.utils.auths import ClusterAuth
 from backend.utils.error_codes import error_codes
 from backend.utils.renderers import BKAPIRenderer
 
@@ -28,7 +29,7 @@ class CRDViewSet(viewsets.ViewSet):
     renderer_classes = (BKAPIRenderer, BrowsableAPIRenderer)
 
     def list(self, request, project_id, cluster_id):
-        crd_client = CustomResourceDefinition(request.user.token.access_token, project_id, cluster_id)
+        crd_client = CustomResourceDefinition(ClusterAuth(request.user.token.access_token, project_id, cluster_id))
         return Response(crd_client.list())
 
 
@@ -36,23 +37,23 @@ class CustomObjectViewSet(viewsets.ViewSet):
     renderer_classes = (BKAPIRenderer, BrowsableAPIRenderer)
 
     def list_custom_objects(self, request, project_id, cluster_id, crd_name):
+        cluster_auth = ClusterAuth(request.user.token.access_token, project_id, cluster_id)
         # 指定api_version是因为当前to_table_format解析的是apiextensions.k8s.io/v1beta1版本的结构
         crd_client = CustomResourceDefinition(
-            request.user.token.access_token, project_id, cluster_id, api_version="apiextensions.k8s.io/v1beta1"
+            cluster_auth,
+            api_version="apiextensions.k8s.io/v1beta1",
         )
         crd = crd_client.get(name=crd_name, is_format=False)
         if not crd:
             raise error_codes.ResNotFoundError(_("集群({})中未注册自定义资源({})").format(cluster_id, crd_name))
 
-        cobj_client = get_custom_object_client_by_crd(
-            request.user.token.access_token, project_id, cluster_id, crd_name
-        )
+        cobj_client = get_cobj_client_by_crd(cluster_auth, crd_name)
         cobj_list = cobj_client.list(namespace=request.query_params.get("namespace"))
         return Response(to_table_format(crd.to_dict(), cobj_list))
 
     def get_custom_object(self, request, project_id, cluster_id, crd_name, name):
-        cobj_client = get_custom_object_client_by_crd(
-            request.user.token.access_token, project_id, cluster_id, crd_name
+        cobj_client = get_cobj_client_by_crd(
+            ClusterAuth(request.user.token.access_token, project_id, cluster_id), crd_name
         )
         cobj_dict = cobj_client.get(namespace=request.query_params.get("namespace"), name=name)
         return Response(cobj_dict)
@@ -62,8 +63,8 @@ class CustomObjectViewSet(viewsets.ViewSet):
         serializer.is_valid(raise_exception=True)
 
         validated_data = serializer.validated_data
-        cobj_client = get_custom_object_client_by_crd(
-            request.user.token.access_token, project_id, cluster_id, crd_name
+        cobj_client = get_cobj_client_by_crd(
+            ClusterAuth(request.user.token.access_token, project_id, cluster_id), crd_name
         )
         cobj_client.patch(
             name=name,
@@ -81,8 +82,8 @@ class CustomObjectViewSet(viewsets.ViewSet):
         serializer.is_valid(raise_exception=True)
 
         validated_data = serializer.validated_data
-        cobj_client = get_custom_object_client_by_crd(
-            request.user.token.access_token, project_id, cluster_id, crd_name
+        cobj_client = get_cobj_client_by_crd(
+            ClusterAuth(request.user.token.access_token, project_id, cluster_id), crd_name
         )
         cobj_client.patch(
             name=name,
@@ -94,8 +95,8 @@ class CustomObjectViewSet(viewsets.ViewSet):
         return Response()
 
     def delete_custom_object(self, request, project_id, cluster_id, crd_name, name):
-        cobj_client = get_custom_object_client_by_crd(
-            request.user.token.access_token, project_id, cluster_id, crd_name
+        cobj_client = get_cobj_client_by_crd(
+            ClusterAuth(request.user.token.access_token, project_id, cluster_id), crd_name
         )
         cobj_client.delete_ignore_nonexistent(namespace=request.query_params.get("namespace"), name=name)
         return Response()

--- a/bcs-app/backend/dashboard/custom_object/views.py
+++ b/bcs-app/backend/dashboard/custom_object/views.py
@@ -11,11 +11,13 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 #
+from django.utils.translation import ugettext_lazy as _
 from rest_framework import viewsets
 from rest_framework.renderers import BrowsableAPIRenderer
 from rest_framework.response import Response
 
-from backend.resources.custom_object import CustomResourceDefinition, get_custom_object_api_by_crd
+from backend.resources.custom_object import CustomResourceDefinition, get_custom_object_client_by_crd
+from backend.utils.error_codes import error_codes
 from backend.utils.renderers import BKAPIRenderer
 
 from .serializers import PatchCustomObjectScaleSLZ, PatchCustomObjectSLZ
@@ -26,8 +28,8 @@ class CRDViewSet(viewsets.ViewSet):
     renderer_classes = (BKAPIRenderer, BrowsableAPIRenderer)
 
     def list(self, request, project_id, cluster_id):
-        crd_api = CustomResourceDefinition(request.user.token.access_token, project_id, cluster_id)
-        return Response(crd_api.list())
+        crd_client = CustomResourceDefinition(request.user.token.access_token, project_id, cluster_id)
+        return Response(crd_client.list())
 
 
 class CustomObjectViewSet(viewsets.ViewSet):
@@ -35,19 +37,24 @@ class CustomObjectViewSet(viewsets.ViewSet):
 
     def list_custom_objects(self, request, project_id, cluster_id, crd_name):
         # 指定api_version是因为当前to_table_format解析的是apiextensions.k8s.io/v1beta1版本的结构
-        crd_api = CustomResourceDefinition(
+        crd_client = CustomResourceDefinition(
             request.user.token.access_token, project_id, cluster_id, api_version="apiextensions.k8s.io/v1beta1"
         )
-        crd_dict = crd_api.get(name=crd_name)
+        crd = crd_client.get(name=crd_name, is_format=False)
+        if not crd:
+            raise error_codes.ResNotFoundError(_("集群({})中未注册自定义资源({})").format(cluster_id, crd_name))
 
-        cobj_api = get_custom_object_api_by_crd(request.user.token.access_token, project_id, cluster_id, crd_name)
-        cobj_list = cobj_api.list(namespace=request.query_params.get("namespace"))
-
-        return Response(to_table_format(crd_dict, cobj_list))
+        cobj_client = get_custom_object_client_by_crd(
+            request.user.token.access_token, project_id, cluster_id, crd_name
+        )
+        cobj_list = cobj_client.list(namespace=request.query_params.get("namespace"))
+        return Response(to_table_format(crd.to_dict(), cobj_list))
 
     def get_custom_object(self, request, project_id, cluster_id, crd_name, name):
-        cobj_api = get_custom_object_api_by_crd(request.user.token.access_token, project_id, cluster_id, crd_name)
-        cobj_dict = cobj_api.get(namespace=request.query_params.get("namespace"), name=name)
+        cobj_client = get_custom_object_client_by_crd(
+            request.user.token.access_token, project_id, cluster_id, crd_name
+        )
+        cobj_dict = cobj_client.get(namespace=request.query_params.get("namespace"), name=name)
         return Response(cobj_dict)
 
     def patch_custom_object(self, request, project_id, cluster_id, crd_name, name):
@@ -55,8 +62,10 @@ class CustomObjectViewSet(viewsets.ViewSet):
         serializer.is_valid(raise_exception=True)
 
         validated_data = serializer.validated_data
-        cobj_api = get_custom_object_api_by_crd(request.user.token.access_token, project_id, cluster_id, crd_name)
-        cobj_api.patch(
+        cobj_client = get_custom_object_client_by_crd(
+            request.user.token.access_token, project_id, cluster_id, crd_name
+        )
+        cobj_client.patch(
             name=name,
             namespace=validated_data.get("namespace"),
             body=validated_data["body"],
@@ -72,8 +81,10 @@ class CustomObjectViewSet(viewsets.ViewSet):
         serializer.is_valid(raise_exception=True)
 
         validated_data = serializer.validated_data
-        cobj_api = get_custom_object_api_by_crd(request.user.token.access_token, project_id, cluster_id, crd_name)
-        cobj_api.patch(
+        cobj_client = get_custom_object_client_by_crd(
+            request.user.token.access_token, project_id, cluster_id, crd_name
+        )
+        cobj_client.patch(
             name=name,
             namespace=validated_data.get("namespace"),
             body=validated_data["body"],
@@ -83,6 +94,8 @@ class CustomObjectViewSet(viewsets.ViewSet):
         return Response()
 
     def delete_custom_object(self, request, project_id, cluster_id, crd_name, name):
-        cobj_api = get_custom_object_api_by_crd(request.user.token.access_token, project_id, cluster_id, crd_name)
-        cobj_api.delete_ignore_nonexistent(namespace=request.query_params.get("namespace"), name=name)
+        cobj_client = get_custom_object_client_by_crd(
+            request.user.token.access_token, project_id, cluster_id, crd_name
+        )
+        cobj_client.delete_ignore_nonexistent(namespace=request.query_params.get("namespace"), name=name)
         return Response()

--- a/bcs-app/backend/resources/custom_object/custom_object.py
+++ b/bcs-app/backend/resources/custom_object/custom_object.py
@@ -13,6 +13,10 @@
 #
 from typing import Optional
 
+from django.utils.translation import ugettext_lazy as _
+
+from backend.utils.error_codes import error_codes
+
 from ..resource import ResourceClient
 from .crd import CustomResourceDefinition
 from .format import CustomObjectFormatter
@@ -28,7 +32,11 @@ class CustomObject(ResourceClient):
         super().__init__(access_token, project_id, cluster_id, api_version)
 
 
-def get_custom_object_api_by_crd(access_token: str, project_id: str, cluster_id: str, crd_name: str) -> CustomObject:
-    crd_api = CustomResourceDefinition(access_token, project_id, cluster_id)
-    crd = crd_api.get(name=crd_name, is_format=False)
-    return CustomObject(access_token, project_id, cluster_id, kind=crd.spec.names.kind)
+def get_custom_object_client_by_crd(
+    access_token: str, project_id: str, cluster_id: str, crd_name: str
+) -> CustomObject:
+    crd_client = CustomResourceDefinition(access_token, project_id, cluster_id)
+    crd = crd_client.get(name=crd_name, is_format=False)
+    if crd:
+        return CustomObject(access_token, project_id, cluster_id, kind=crd.spec.names.kind)
+    raise error_codes.ResNotFoundError(_("集群({})中未注册自定义资源({})").format(cluster_id, crd_name))

--- a/bcs-app/backend/resources/custom_object/custom_object.py
+++ b/bcs-app/backend/resources/custom_object/custom_object.py
@@ -18,6 +18,7 @@ from django.utils.translation import ugettext_lazy as _
 from backend.utils.error_codes import error_codes
 
 from ..resource import ResourceClient
+from ..utils.auths import ClusterAuth
 from .crd import CustomResourceDefinition
 from .format import CustomObjectFormatter
 
@@ -25,18 +26,14 @@ from .format import CustomObjectFormatter
 class CustomObject(ResourceClient):
     formatter = CustomObjectFormatter()
 
-    def __init__(
-        self, access_token: str, project_id: str, cluster_id: str, kind: str, api_version: Optional[str] = None
-    ):
+    def __init__(self, cluster_auth: ClusterAuth, kind: str, api_version: Optional[str] = None):
         self.kind = kind
-        super().__init__(access_token, project_id, cluster_id, api_version)
+        super().__init__(cluster_auth, api_version)
 
 
-def get_custom_object_client_by_crd(
-    access_token: str, project_id: str, cluster_id: str, crd_name: str
-) -> CustomObject:
-    crd_client = CustomResourceDefinition(access_token, project_id, cluster_id)
+def get_cobj_client_by_crd(cluster_auth: ClusterAuth, crd_name: str) -> CustomObject:
+    crd_client = CustomResourceDefinition(cluster_auth)
     crd = crd_client.get(name=crd_name, is_format=False)
     if crd:
-        return CustomObject(access_token, project_id, cluster_id, kind=crd.spec.names.kind)
-    raise error_codes.ResNotFoundError(_("集群({})中未注册自定义资源({})").format(cluster_id, crd_name))
+        return CustomObject(cluster_auth, kind=crd.spec.names.kind)
+    raise error_codes.ResNotFoundError(_("集群({})中未注册自定义资源({})").format(cluster_auth.cluster_id, crd_name))

--- a/bcs-app/backend/resources/resource.py
+++ b/bcs-app/backend/resources/resource.py
@@ -18,6 +18,7 @@ from kubernetes.dynamic.resource import ResourceInstance
 from backend.resources.utils.kube_client import get_dynamic_client
 
 from .constants import PatchType
+from .utils.auths import ClusterAuth
 from .utils.format import ResourceDefaultFormatter
 
 
@@ -29,8 +30,10 @@ class ResourceClient:
     kind = "Resource"
     formatter = ResourceDefaultFormatter()
 
-    def __init__(self, access_token: str, project_id: str, cluster_id: str, api_version: Optional[str] = None):
-        self.dynamic_client = get_dynamic_client(access_token, project_id, cluster_id)
+    def __init__(self, cluster_auth: ClusterAuth, api_version: Optional[str] = None):
+        self.dynamic_client = get_dynamic_client(
+            cluster_auth.access_token, cluster_auth.project_id, cluster_auth.cluster_id
+        )
         if api_version:
             self.api = self.dynamic_client.resources.get(kind=self.kind, api_version=api_version)
         else:

--- a/bcs-app/backend/resources/resource.py
+++ b/bcs-app/backend/resources/resource.py
@@ -36,13 +36,13 @@ class ResourceClient:
         else:
             self.api = self.dynamic_client.get_preferred_resource(self.kind)
 
-    def list(self, is_format: bool = True, **kwargs) -> Union[ResourceInstance, List]:
+    def list(self, is_format: bool = True, **kwargs) -> Union[ResourceInstance, List, None]:
         resp = self.api.get_or_none(**kwargs)
         if is_format:
             return self.formatter.format_list(resp)
         return resp
 
-    def get(self, name, is_format: bool = True, **kwargs) -> Union[ResourceInstance, Dict]:
+    def get(self, name, is_format: bool = True, **kwargs) -> Union[ResourceInstance, Dict, None]:
         resp = self.api.get_or_none(name=name, **kwargs)
         if is_format:
             return self.formatter.format(resp)

--- a/bcs-app/backend/resources/utils/auths.py
+++ b/bcs-app/backend/resources/utils/auths.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community Edition) available.
+# Copyright (C) 2017-2019 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+from dataclasses import dataclass
+
+
+@dataclass
+class ClusterAuth:
+    access_token: str
+    project_id: str
+    cluster_id: str

--- a/bcs-app/backend/resources/utils/discovery.py
+++ b/bcs-app/backend/resources/utils/discovery.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+#
+# Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community Edition) available.
+# Copyright (C) 2017-2019 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+import json
+import logging
+from functools import partial
+
+from kubernetes import __version__
+from kubernetes.dynamic.discovery import CacheDecoder, CacheEncoder, LazyDiscoverer
+
+from backend.utils.cache import rd_client
+
+
+class DiscovererCache:
+    def __init__(self, cache_key):
+        self.cache_key = cache_key
+        self.rd_client = rd_client
+
+    def exists(self) -> bool:
+        return self.rd_client.exists(self.cache_key)
+
+    def get_content(self) -> bytes:
+        return self.rd_client.get(self.cache_key)
+
+    def set_content(self, content: str):
+        self.rd_client.set(self.cache_key, content)
+
+
+class BcsLazyDiscoverer(LazyDiscoverer):
+    """
+    - override Discoverer 中的 __init_cache 方法，修复 'CacheDecoder' object is not callable
+    - 用redis替代文件缓存
+    """
+
+    def _Discoverer__init_cache(self, refresh=False):
+        discoverer_cache = self._Discoverer__cache_file
+
+        if refresh or not discoverer_cache.exists():
+            self._cache = {'library_version': __version__}
+            refresh = True
+        else:
+            try:
+                self._cache = json.loads(discoverer_cache.get_content(), cls=partial(CacheDecoder, self.client))
+                if self._cache.get('library_version') != __version__:
+                    # Version mismatch, need to refresh cache
+                    self.invalidate_cache()
+            except Exception as e:
+                logging.error("load cache error: %s", e)
+                self.invalidate_cache()
+        self._load_server_info()
+        self.discover()
+        if refresh:
+            self._write_cache()
+
+    def _write_cache(self):
+        try:
+            discoverer_cache = self._Discoverer__cache_file
+            cache_content = json.dumps(self._cache, cls=CacheEncoder)
+            discoverer_cache.set_content(cache_content)
+        except Exception as e:
+            # Failing to write the cache isn't a big enough error to crash on
+            logging.error("write cache error: %s", e)

--- a/bcs-app/backend/resources/utils/kube_client.py
+++ b/bcs-app/backend/resources/utils/kube_client.py
@@ -11,57 +11,19 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 #
-import json
 import logging
-from functools import lru_cache, partial
+from functools import lru_cache
 from typing import Any, Dict, Optional, Tuple
 
-from kubernetes import __version__, client
+from kubernetes import client
 from kubernetes.client.exceptions import ApiException
 from kubernetes.dynamic import DynamicClient, Resource, ResourceInstance
-from kubernetes.dynamic.discovery import CacheDecoder, CacheEncoder, LazyDiscoverer
 from kubernetes.dynamic.exceptions import ResourceNotUniqueError
 
-from backend.resources.client import BcsKubeConfigurationService
-from backend.utils.cache import rd_client
+from ..client import BcsKubeConfigurationService
+from .discovery import BcsLazyDiscoverer, DiscovererCache
 
 logger = logging.getLogger(__name__)
-
-
-class BcsLazyDiscoverer(LazyDiscoverer):
-    """
-    - override Discoverer 中的 __init_cache 方法，修复 'CacheDecoder' object is not callable
-    - 用redis替代文件缓存
-    """
-
-    def _Discoverer__init_cache(self, refresh=False):
-        cache_key = self._Discoverer__cache_file
-
-        if refresh or not rd_client.exists(cache_key):
-            self._cache = {'library_version': __version__}
-            refresh = True
-        else:
-            try:
-                self._cache = json.loads(rd_client.get(cache_key), cls=partial(CacheDecoder, self.client))
-                if self._cache.get('library_version') != __version__:
-                    # Version mismatch, need to refresh cache
-                    self.invalidate_cache()
-            except Exception as e:
-                logging.error("load cache error: %s", e)
-                self.invalidate_cache()
-        self._load_server_info()
-        self.discover()
-        if refresh:
-            self._write_cache()
-
-    def _write_cache(self):
-        try:
-            cache_key = self._Discoverer__cache_file
-            cache_content = json.dumps(self._cache, cls=CacheEncoder)
-            rd_client.set(cache_key, cache_content)
-        except Exception as e:
-            # Failing to write the cache isn't a big enough error to crash on
-            logging.error("write cache error: %s", e)
 
 
 class CoreDynamicClient(DynamicClient):
@@ -171,8 +133,8 @@ def get_dynamic_client(access_token: str, project_id: str, cluster_id: str) -> C
     """根据 token、cluster_id 等参数，构建访问 Kubernetes 集群的 Client 对象"""
     config = BcsKubeConfigurationService(access_token, project_id, cluster_id).make_configuration()
     # TODO 考虑集群可能升级k8s版本的情况, 缓存文件会失效
-    cache_key = f"osrcp-{cluster_id}.json"
-    return CoreDynamicClient(client.ApiClient(config), cache_file=cache_key, discoverer=BcsLazyDiscoverer)
+    discoverer_cache = DiscovererCache(cache_key=f"osrcp-{cluster_id}.json")
+    return CoreDynamicClient(client.ApiClient(config), cache_file=discoverer_cache, discoverer=BcsLazyDiscoverer)
 
 
 def make_labels_string(labels: Dict) -> str:

--- a/bcs-app/backend/tests/resources/custom_object/test_custom_object.py
+++ b/bcs-app/backend/tests/resources/custom_object/test_custom_object.py
@@ -16,7 +16,8 @@ import pytest
 
 from backend.resources.constants import PatchType
 from backend.resources.custom_object.crd import CustomResourceDefinition
-from backend.resources.custom_object.custom_object import get_custom_object_client_by_crd
+from backend.resources.custom_object.custom_object import get_cobj_client_by_crd
+from backend.resources.utils.auths import ClusterAuth
 from backend.utils.basic import getitems
 
 from ..conftest import FakeBcsKubeConfigurationService
@@ -58,7 +59,9 @@ class TestCRDAndCustomObject:
 
     @pytest.fixture
     def crd_client(self, project_id, cluster_id):
-        return CustomResourceDefinition('token', project_id, cluster_id, api_version=sample_crd["apiVersion"])
+        return CustomResourceDefinition(
+            ClusterAuth('token', project_id, cluster_id), api_version=sample_crd["apiVersion"]
+        )
 
     @pytest.fixture
     def update_or_create_crd(self, crd_client):
@@ -68,8 +71,8 @@ class TestCRDAndCustomObject:
 
     @pytest.fixture
     def cobj_client(self, project_id, cluster_id):
-        return get_custom_object_client_by_crd(
-            'token', project_id, cluster_id, crd_name=getitems(sample_crd, "metadata.name")
+        return get_cobj_client_by_crd(
+            ClusterAuth('token', project_id, cluster_id), crd_name=getitems(sample_crd, "metadata.name")
         )
 
     @pytest.fixture

--- a/bcs-app/backend/tests/resources/custom_object/test_custom_object.py
+++ b/bcs-app/backend/tests/resources/custom_object/test_custom_object.py
@@ -16,7 +16,7 @@ import pytest
 
 from backend.resources.constants import PatchType
 from backend.resources.custom_object.crd import CustomResourceDefinition
-from backend.resources.custom_object.custom_object import get_custom_object_api_by_crd
+from backend.resources.custom_object.custom_object import get_custom_object_client_by_crd
 from backend.utils.basic import getitems
 
 from ..conftest import FakeBcsKubeConfigurationService
@@ -57,42 +57,44 @@ class TestCRDAndCustomObject:
             yield
 
     @pytest.fixture
-    def crd_api(self, project_id, cluster_id):
+    def crd_client(self, project_id, cluster_id):
         return CustomResourceDefinition('token', project_id, cluster_id, api_version=sample_crd["apiVersion"])
 
     @pytest.fixture
-    def update_or_create_crd(self, crd_api):
-        crd_api.update_or_create(body=sample_crd)
+    def update_or_create_crd(self, crd_client):
+        crd_client.update_or_create(body=sample_crd)
         yield
-        crd_api.delete_ignore_nonexistent(name=getitems(sample_crd, "metadata.name"), namespace="default")
+        crd_client.delete_ignore_nonexistent(name=getitems(sample_crd, "metadata.name"), namespace="default")
 
     @pytest.fixture
-    def cobj_api(self, project_id, cluster_id):
-        return get_custom_object_api_by_crd(
+    def cobj_client(self, project_id, cluster_id):
+        return get_custom_object_client_by_crd(
             'token', project_id, cluster_id, crd_name=getitems(sample_crd, "metadata.name")
         )
 
     @pytest.fixture
-    def update_or_create_custom_object(self, cobj_api):
-        cobj_api.update_or_create(
+    def update_or_create_custom_object(self, cobj_client):
+        cobj_client.update_or_create(
             body=sample_custom_object, namespace="default", name=getitems(sample_custom_object, "metadata.name")
         )
         yield
-        cobj_api.delete_ignore_nonexistent(name=getitems(sample_custom_object, "metadata.name"), namespace="default")
+        cobj_client.delete_ignore_nonexistent(
+            name=getitems(sample_custom_object, "metadata.name"), namespace="default"
+        )
 
-    def test_crd_list(self, crd_api, update_or_create_crd):
-        crd_lists = crd_api.list()
+    def test_crd_list(self, crd_client, update_or_create_crd):
+        crd_lists = crd_client.list()
         assert isinstance(crd_lists, list)
 
-    def test_crd_get(self, crd_api, update_or_create_crd):
-        crd = crd_api.get(name=getitems(sample_crd, "metadata.name"), is_format=False)
+    def test_crd_get(self, crd_client, update_or_create_crd):
+        crd = crd_client.get(name=getitems(sample_crd, "metadata.name"), is_format=False)
         assert crd.spec.scope == "Namespaced"
 
-        crd = crd_api.get(name="no.k3s.cattle.io", is_format=False)
+        crd = crd_client.get(name="no.k3s.cattle.io", is_format=False)
         assert crd is None
 
-    def test_custom_object_patch(self, update_or_create_crd, cobj_api, update_or_create_custom_object):
-        cobj = cobj_api.patch(
+    def test_custom_object_patch(self, update_or_create_crd, cobj_client, update_or_create_custom_object):
+        cobj = cobj_client.patch(
             name=getitems(sample_custom_object, "metadata.name"),
             namespace="default",
             body={"spec": {"replicas": 2}},


### PR DESCRIPTION
变更点(Changes)
- 修复Discoverer中 CacheDecoder object is not callable的bug
- 调整crd部分逻辑，主要是变量命名`_api`=>`_client`
- 使用redis缓存api resources