### PR TITLE
fix: Uppercase ext_context in settings

### DIFF
--- a/bcs-app/backend/utils/views.py
+++ b/bcs-app/backend/utils/views.py
@@ -295,7 +295,7 @@ class VueTemplateView(TemplateView):
         }
 
         # 增加扩展的字段渲染前端页面，用于多版本
-        ext_context = getattr(settings, 'ext_context', {})
+        ext_context = getattr(settings, 'EXT_CONTEXT', {})
         if ext_context:
             context.update(ext_context)
 


### PR DESCRIPTION
变更点(Changes)
settings中的配置需要大小，大写ext_context