### PR TITLE
minor: set show_version_id to dict when audit extra args

### DIFF
--- a/bcs-app/backend/templatesets/legacy_apps/configuration/showversion/views.py
+++ b/bcs-app/backend/templatesets/legacy_apps/configuration/showversion/views.py
@@ -196,7 +196,9 @@ class ShowVersionViewSet(viewsets.ViewSet, TemplatePermission):
             show_version = models.ShowVersion.objects.get(template_id=template.id, id=show_version_id)
             version_name = show_version.name
             show_version.delete()
-            audit_ctx_kwargs.update({'extra': show_version_id, 'description': _("删除版本[{}]").format(version_name)})
+            audit_ctx_kwargs.update(
+                {'extra': {'show_version_id': show_version_id}, 'description': _("删除版本[{}]").format(version_name)}
+            )
 
         self.audit_ctx.update_fields(**audit_ctx_kwargs)
 


### PR DESCRIPTION
变更点(Changes)
审计时，调整extra参数记录，由 show_version_id 改成 {”show_version_id“： show_version_id} 。
否则会抛异常：ValueError: dictionary update sequence element #0 has length 1; 2 is required