### PR TITLE
feat: add response_perms decorator to inject perms data to resp

### DIFF
--- a/bcs-app/backend/helm/helm/utils/repo_bk.py
+++ b/bcs-app/backend/helm/helm/utils/repo_bk.py
@@ -11,12 +11,12 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 #
-import base64
-import hashlib
 import logging
 
 import requests
 import yaml
+
+from backend.utils.basic import md5
 
 logger = logging.getLogger(__name__)
 
@@ -33,12 +33,6 @@ def make_requests_auth(auth):
         )
 
     raise NotImplementedError(auth["type"])
-
-
-def _md5(content):
-    h = hashlib.md5()
-    h.update(content.encode("utf-8"))
-    return h.hexdigest()
 
 
 def get_charts_info(url, auths):
@@ -61,7 +55,7 @@ def get_charts_info(url, auths):
         return (False, None, None)
 
     # 生成MD5，主要是便于后续校验是否变动
-    charts_info_hash = _md5(str(charts_info))
+    charts_info_hash = md5(str(charts_info))
     return (True, charts_info, charts_info_hash)
 
 

--- a/bcs-app/backend/iam/permissions/client.py
+++ b/bcs-app/backend/iam/permissions/client.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017-2021 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from typing import Dict, List, Optional
+
+from django.conf import settings
+from iam import IAM, Action, MultiActionRequest, Request, Resource, Subject
+
+from .request import ResourceRequest
+
+
+class IAMClient:
+    """提供基础的 iam client 方法封装"""
+
+    iam = IAM(settings.APP_ID, settings.APP_TOKEN, settings.BK_IAM_HOST, settings.BK_PAAS_INNER_HOST)
+
+    def resource_type_allowed(self, username: str, action_id: str, use_cache: bool = False) -> bool:
+        """
+        判断用户是否具备某个操作的权限
+        note: 权限判断与资源实例无关，如创建某资源
+        """
+        request = self._make_request(username, action_id)
+        if not use_cache:
+            return self.iam.is_allowed(request)
+        return self.iam.is_allowed_with_cache(request)
+
+    def resource_inst_allowed(
+        self, username: str, action_id: str, res_request: ResourceRequest, use_cache: bool = False
+    ) -> bool:
+        """
+        判断用户对某个资源实例是否具有指定操作的权限
+        note: 权限判断与资源实例有关，如更新某个具体资源
+        """
+        request = self._make_request(username, action_id, resources=res_request.make_resources())
+        if not use_cache:
+            return self.iam.is_allowed(request)
+        return self.iam.is_allowed_with_cache(request)
+
+    def resource_type_multi_actions_allowed(self, username: str, action_ids: List[str]) -> Dict[str, bool]:
+        """
+        判断用户是否具备多个操作的权限
+        note: 权限判断与资源实例无关，如创建某资源
+
+        :returns 示例 {'project_create': True}
+        """
+        return {action_id: self.resource_type_allowed(username, action_id) for action_id in action_ids}
+
+    def resource_inst_multi_actions_allowed(
+        self, username: str, action_ids: List[str], res_request: ResourceRequest
+    ) -> Dict[str, bool]:
+        """
+        判断用户对某个资源实例是否具有多个操作的权限.
+        note: 权限判断与资源实例有关，如更新某个具体资源
+
+        :returns 示例 {'project_view': True, 'project_edit': False}
+        """
+        actions = [Action(action_id) for action_id in action_ids]
+        request = MultiActionRequest(
+            settings.APP_ID, Subject("user", username), actions, res_request.make_resources(), None
+        )
+        return self.iam.resource_multi_actions_allowed(request)
+
+    def batch_resource_multi_actions_allowed(
+        self, username: str, action_ids: List[str], res_request: ResourceRequest
+    ) -> Dict[str, Dict[str, bool]]:
+        """
+        判断用户对某些资源是否具有多个指定操作的权限
+        note: 当前sdk仅支持同类型的资源
+
+        :returns 示例 {'0ad86c25363f4ef8adcb7ac67a483837': {'project_view': True, 'project_edit': False}}
+        """
+        actions = [Action(action_id) for action_id in action_ids]
+        request = MultiActionRequest(settings.APP_ID, Subject("user", username), actions, [], None)
+        return self.iam.batch_resource_multi_actions_allowed(request, res_request.make_resources())
+
+    def _make_request(self, username: str, action_id: str, resources: Optional[List[Resource]] = None) -> Request:
+        return Request(
+            settings.APP_ID,
+            Subject("user", username),
+            Action(action_id),
+            resources,
+            None,
+        )
+
+    def _grant_resource_creator_actions(self, username: str, resource_type: str, resource_id: str, resource_name: str):
+        """
+        用于创建资源时，注册用户对该资源的关联操作权限.
+        note: 具体的关联操作见权限模型的 resource_creator_actions 字段
+        """
+        data = {
+            "type": resource_type,
+            "id": resource_id,
+            "name": resource_name,
+            "system": settings.APP_ID,
+            "creator": username,
+        }
+        return self.iam._client.grant_resource_creator_actions(None, username, data)

--- a/bcs-app/backend/iam/permissions/client.py
+++ b/bcs-app/backend/iam/permissions/client.py
@@ -80,7 +80,8 @@ class IAMClient:
         """
         actions = [Action(action_id) for action_id in action_ids]
         request = MultiActionRequest(settings.APP_ID, Subject("user", username), actions, [], None)
-        return self.iam.batch_resource_multi_actions_allowed(request, res_request.make_resources())
+        resources_list = [[res] for res in res_request.make_resources()]
+        return self.iam.batch_resource_multi_actions_allowed(request, resources_list)
 
     def _make_request(self, username: str, action_id: str, resources: Optional[List[Resource]] = None) -> Request:
         return Request(

--- a/bcs-app/backend/iam/permissions/decorators.py
+++ b/bcs-app/backend/iam/permissions/decorators.py
@@ -14,12 +14,17 @@
 import importlib
 import logging
 from abc import ABCMeta, abstractmethod
+from typing import List, Type
 
 import wrapt
 
+from backend.utils.basic import str2bool
+
+from .client import IAMClient
 from .exceptions import PermissionDeniedError
 from .perm import PermCtx
 from .perm import Permission as PermPermission
+from .request import ResourceRequest
 
 logger = logging.getLogger(__name__)
 
@@ -138,3 +143,50 @@ class Permission:
         getattr(self.perm_obj, self.method_name)(args[0])
 
         return wrapped(*args, **kwargs)
+
+
+class response_perms:
+    def __init__(
+        self,
+        action_id_list: List[str],
+        res_request_cls: Type[ResourceRequest],
+        resource_id_key: str = 'id',
+        auto_add: bool = True,
+    ):
+        self.action_id_list = action_id_list
+        self.res_request_cls = res_request_cls
+        self.resource_id_key = resource_id_key
+        self.auto_add = auto_add
+
+    @wrapt.decorator
+    def __call__(self, wrapped, instance, args, kwargs):
+        resp = wrapped(*args, **kwargs)
+        if not resp.data:
+            return resp
+
+        with_perms = self.auto_add
+        request = args[0]
+        if not self.auto_add:
+            with_perms = str2bool(request.query_params.get('with_perms') or True)
+
+        if not with_perms:
+            return resp
+
+        client = IAMClient()
+        if isinstance(resp.data, list):
+            res = [item.get(self.resource_id_key) for item in resp.data]
+        else:
+            res = resp.data.get(self.resource_id_key)
+
+        perms = client.batch_resource_multi_actions_allowed(
+            request.user.username,
+            self.action_id_list,
+            self.res_request_cls(res, **getattr(request, 'iam_path_attrs', {})),
+        )
+
+        if hasattr(resp, "web_annotations"):
+            resp.web_annotations = resp.web_annotations or {}
+            resp.web_annotations.update({"perms": perms})
+        else:
+            resp.web_annotations = {"perms": perms}
+        return resp

--- a/bcs-app/backend/iam/permissions/decorators.py
+++ b/bcs-app/backend/iam/permissions/decorators.py
@@ -99,10 +99,6 @@ class RelatedPermission(metaclass=ABCMeta):
     def _convert_perm_ctx(self, instance, args, kwargs) -> PermCtx:
         """将被装饰的方法中的 perm_ctx 转换成 perm_obj.method_name 需要的 perm_ctx"""
 
-    @abstractmethod
-    def _action_request_list(self, perm_ctx: PermCtx) -> List[ActionResourcesRequest]:
-        """从 perm_ctx 中解析生成 action_request_list"""
-
     @property
     def action_id(self) -> str:
         return f'{self.perm_obj.resource_type}_{self.method_name[4:]}'

--- a/bcs-app/backend/iam/permissions/decorators.py
+++ b/bcs-app/backend/iam/permissions/decorators.py
@@ -14,12 +14,11 @@
 import importlib
 import logging
 from abc import ABCMeta, abstractmethod
-from typing import List
 
 import wrapt
 
 from .exceptions import PermissionDeniedError
-from .perm import ActionResourcesRequest, PermCtx
+from .perm import PermCtx
 from .perm import Permission as PermPermission
 
 logger = logging.getLogger(__name__)

--- a/bcs-app/backend/iam/permissions/perm.py
+++ b/bcs-app/backend/iam/permissions/perm.py
@@ -14,103 +14,13 @@
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Type
+from typing import Optional, Type
 
-from django.conf import settings
-from iam import IAM, Action, MultiActionRequest, Request, Resource, Subject
-
+from .client import IAMClient
 from .exceptions import PermissionDeniedError
 from .request import ActionResourcesRequest, ResourceRequest
 
 logger = logging.getLogger(__name__)
-
-
-class IAMClient:
-    """提供基础的 iam client 方法封装"""
-
-    iam = IAM(settings.APP_ID, settings.APP_TOKEN, settings.BK_IAM_HOST, settings.BK_PAAS_INNER_HOST)
-
-    def resource_type_allowed(self, username: str, action_id: str, use_cache: bool = False) -> bool:
-        """
-        判断用户是否具备某个操作的权限
-        note: 权限判断与资源实例无关，如创建某资源
-        """
-        request = self._make_request(username, action_id)
-        if not use_cache:
-            return self.iam.is_allowed(request)
-        return self.iam.is_allowed_with_cache(request)
-
-    def resource_inst_allowed(
-        self, username: str, action_id: str, res_request: ResourceRequest, use_cache: bool = False
-    ) -> bool:
-        """
-        判断用户对某个资源实例是否具有指定操作的权限
-        note: 权限判断与资源实例有关，如更新某个具体资源
-        """
-        request = self._make_request(username, action_id, resources=res_request.make_resources())
-        if not use_cache:
-            return self.iam.is_allowed(request)
-        return self.iam.is_allowed_with_cache(request)
-
-    def resource_type_multi_actions_allowed(self, username: str, action_ids: List[str]) -> Dict[str, bool]:
-        """
-        判断用户是否具备多个操作的权限
-        note: 权限判断与资源实例无关，如创建某资源
-
-        :returns 示例 {'project_create': True}
-        """
-        return {action_id: self.resource_type_allowed(username, action_id) for action_id in action_ids}
-
-    def resource_inst_multi_actions_allowed(
-        self, username: str, action_ids: List[str], res_request: ResourceRequest
-    ) -> Dict[str, bool]:
-        """
-        判断用户对某个资源实例是否具有多个操作的权限.
-        note: 权限判断与资源实例有关，如更新某个具体资源
-
-        :returns 示例 {'project_view': True, 'project_edit': False}
-        """
-        actions = [Action(action_id) for action_id in action_ids]
-        request = MultiActionRequest(
-            settings.APP_ID, Subject("user", username), actions, res_request.make_resources(), None
-        )
-        return self.iam.resource_multi_actions_allowed(request)
-
-    def batch_resource_multi_actions_allowed(
-        self, username: str, action_ids: List[str], res_request: ResourceRequest
-    ) -> Dict[str, Dict[str, bool]]:
-        """
-        判断用户对某些资源是否具有多个指定操作的权限
-        note: 当前sdk仅支持同类型的资源
-
-        :returns 示例 {'0ad86c25363f4ef8adcb7ac67a483837': {'project_view': True, 'project_edit': False}}
-        """
-        actions = [Action(action_id) for action_id in action_ids]
-        request = MultiActionRequest(settings.APP_ID, Subject("user", username), actions, [], None)
-        return self.iam.batch_resource_multi_actions_allowed(request, res_request.make_resources())
-
-    def _make_request(self, username: str, action_id: str, resources: Optional[List[Resource]] = None) -> Request:
-        return Request(
-            settings.APP_ID,
-            Subject("user", username),
-            Action(action_id),
-            resources,
-            None,
-        )
-
-    def _grant_resource_creator_actions(self, username: str, resource_type: str, resource_id: str, resource_name: str):
-        """
-        用于创建资源时，注册用户对该资源的关联操作权限.
-        note: 具体的关联操作见权限模型的 resource_creator_actions 字段
-        """
-        data = {
-            "type": resource_type,
-            "id": resource_id,
-            "name": resource_name,
-            "system": settings.APP_ID,
-            "creator": username,
-        }
-        return self.iam._client.grant_resource_creator_actions(None, username, data)
 
 
 @dataclass

--- a/bcs-app/backend/iam/permissions/perm.py
+++ b/bcs-app/backend/iam/permissions/perm.py
@@ -11,7 +11,8 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 #
-from abc import ABCMeta, abstractmethod
+import logging
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Type
 
@@ -21,63 +22,13 @@ from iam import IAM, Action, MultiActionRequest, Request, Resource, Subject
 from .exceptions import PermissionDeniedError
 from .request import ActionResourcesRequest, ResourceRequest
 
-
-@dataclass
-class PermCtx:
-    """
-    权限参数上下文
-    note: 由于 force_raise 默认值的原因，其子类属性必须设置默认值
-    """
-
-    username: str
-    force_raise: bool = False  # 如果为 True, 表示不做权限校验，直接以无权限方式抛出异常
+logger = logging.getLogger(__name__)
 
 
-class Permission(metaclass=ABCMeta):
-    """
-    对接 IAM 的权限基类
-    """
+class IAMClient:
+    """提供基础的 iam client 方法封装"""
 
-    resource_type: str = ''
-    resource_request_cls: Type[ResourceRequest] = ResourceRequest
     iam = IAM(settings.APP_ID, settings.APP_TOKEN, settings.BK_IAM_HOST, settings.BK_PAAS_INNER_HOST)
-
-    def can_action(self, perm_ctx: PermCtx, action_id: str, raise_exception: bool, use_cache: bool = False) -> bool:
-        """
-        :param perm_ctx: 权限校验的上下文，至少包含用户名
-        :param action_id: 资源操作 ID
-        :param raise_exception: 无权限时，是否抛出异常
-        :param use_cache: 是否使用本地缓存 (缓存时间 1 min) 校验权限。用于非敏感操作鉴权，比如 view 操作
-        """
-        res_id = self._get_resource_id_from_ctx(perm_ctx)
-
-        if perm_ctx.force_raise:
-            self._raise_permission_denied_error(res_id, perm_ctx, action_id)
-
-        if res_id:
-            res_request = self._make_res_request(res_id, perm_ctx)
-            is_allowed = self.resource_inst_allowed(perm_ctx.username, action_id, res_request, use_cache)
-        else:
-            is_allowed = self.resource_type_allowed(perm_ctx.username, action_id, use_cache)
-
-        if raise_exception and not is_allowed:
-            self._raise_permission_denied_error(res_id, perm_ctx, action_id)
-
-        return is_allowed
-
-    def grant_resource_creator_actions(self, username: str, resource_id: str, resource_name: str):
-        """
-        用于创建资源时，注册用户对该资源的关联操作权限.
-        note: 具体的关联操作见权限模型的 resource_creator_actions 字段
-        """
-        data = {
-            "type": self.resource_type,
-            "id": resource_id,
-            "name": resource_name,
-            "system": settings.APP_ID,
-            "creator": username,
-        }
-        return self.iam._client.grant_resource_creator_actions(None, username, data)
 
     def resource_type_allowed(self, username: str, action_id: str, use_cache: bool = False) -> bool:
         """
@@ -95,8 +46,6 @@ class Permission(metaclass=ABCMeta):
         """
         判断用户对某个资源实例是否具有指定操作的权限
         note: 权限判断与资源实例有关，如更新某个具体资源
-
-        :params res_maker: 单个资源
         """
         request = self._make_request(username, action_id, resources=res_request.make_resources())
         if not use_cache:
@@ -119,7 +68,6 @@ class Permission(metaclass=ABCMeta):
         判断用户对某个资源实例是否具有多个操作的权限.
         note: 权限判断与资源实例有关，如更新某个具体资源
 
-        :params res_maker: 多个资源
         :returns 示例 {'project_view': True, 'project_edit': False}
         """
         actions = [Action(action_id) for action_id in action_ids]
@@ -150,20 +98,112 @@ class Permission(metaclass=ABCMeta):
             None,
         )
 
-    def _make_res_request(self, res_id: str, perm_ctx: PermCtx) -> ResourceRequest:
+    def _grant_resource_creator_actions(self, username: str, resource_type: str, resource_id: str, resource_name: str):
+        """
+        用于创建资源时，注册用户对该资源的关联操作权限.
+        note: 具体的关联操作见权限模型的 resource_creator_actions 字段
+        """
+        data = {
+            "type": resource_type,
+            "id": resource_id,
+            "name": resource_name,
+            "system": settings.APP_ID,
+            "creator": username,
+        }
+        return self.iam._client.grant_resource_creator_actions(None, username, data)
+
+
+@dataclass
+class PermCtx:
+    """
+    权限参数上下文
+    note: 由于 force_raise 默认值的原因，其子类属性必须设置默认值
+    """
+
+    username: str
+    force_raise: bool = False  # 如果为 True, 表示不做权限校验，直接以无权限方式抛出异常
+
+
+class Permission(ABC, IAMClient):
+    """
+    对接 IAM 的权限基类
+    """
+
+    resource_type: str = ''
+    resource_request_cls: Type[ResourceRequest] = ResourceRequest
+    parent_perm_obj: Optional['Permission'] = None
+
+    def can_action(self, perm_ctx: PermCtx, action_id: str, raise_exception: bool, use_cache: bool = False) -> bool:
+        """
+        :param perm_ctx: 权限校验的上下文
+        :param action_id: 资源操作 ID
+        :param raise_exception: 无权限时，是否抛出异常
+        :param use_cache: 是否使用本地缓存 (缓存时间 1 min) 校验权限。用于非敏感操作鉴权，比如 view 操作
+        """
+        if perm_ctx.force_raise:
+            self._raise_permission_denied_error(perm_ctx, action_id)
+
+        is_allowed = self._can_action(perm_ctx, action_id, use_cache)
+
+        if raise_exception and not is_allowed:
+            self._raise_permission_denied_error(perm_ctx, action_id)
+
+        return is_allowed
+
+    def grant_resource_creator_actions(self, username: str, resource_id: str, resource_name: str):
+        """
+        用于创建资源时，注册用户对该资源的关联操作权限.
+        note: 具体的关联操作见权限模型的 resource_creator_actions 字段
+        """
+        return self._grant_resource_creator_actions(username, self.resource_type, resource_id, resource_name)
+
+    def make_res_request(self, res_id: str, perm_ctx: PermCtx) -> ResourceRequest:
+        """创建当前资源 request"""
         return self.resource_request_cls(res_id)
 
-    def _raise_permission_denied_error(self, res_id: str, perm_ctx: PermCtx, action_id: str):
-        resources = [res_id] if res_id else None
-        action_request_list = [
-            ActionResourcesRequest(resource_type=self.resource_type, action_id=action_id, resources=resources)
-        ]
+    def has_parent(self) -> bool:
+        return self.parent_perm_obj is not None
+
+    def _can_action(self, perm_ctx: PermCtx, action_id: str, use_cache: bool = False) -> bool:
+        res_id = self._get_resource_id(perm_ctx)
+
+        if res_id:  # 与当前资源实例相关
+            res_request = self.make_res_request(res_id, perm_ctx)
+            return self.resource_inst_allowed(perm_ctx.username, action_id, res_request, use_cache)
+
+        # 与当前资源实例无关, 并且无关联上级资源, 按资源实例无关处理
+        if not self.has_parent():
+            return self.resource_type_allowed(perm_ctx.username, action_id, use_cache)
+
+        # 有关联上级资源
+        request_method = getattr(self.parent_perm_obj, 'make_res_request')
+        res_request = request_method(res_id=self._get_parent_resource_id(perm_ctx), perm_ctx=perm_ctx)
+        return self.resource_inst_allowed(perm_ctx.username, action_id, res_request, use_cache)
+
+    def _raise_permission_denied_error(self, perm_ctx: PermCtx, action_id: str):
+        res_id = self._get_resource_id(perm_ctx)
+
+        resources = None
+        resource_type = self.resource_type
+
+        if res_id:
+            resources = [res_id]
+        elif self.has_parent():
+            resource_type = self.parent_perm_obj.resource_type
+            resources = [self._get_parent_resource_id(perm_ctx)]
+
         raise PermissionDeniedError(
             f"no {action_id} permission",
             username=perm_ctx.username,
-            action_request_list=action_request_list,
+            action_request_list=[
+                ActionResourcesRequest(resource_type=resource_type, action_id=action_id, resources=resources)
+            ],
         )
 
     @abstractmethod
-    def _get_resource_id_from_ctx(self, perm_ctx: PermCtx) -> Optional[str]:
-        """"""
+    def _get_resource_id(self, perm_ctx: PermCtx) -> Optional[str]:
+        """从 ctx 中获取当前资源对应的 id"""
+
+    @abstractmethod
+    def _get_parent_resource_id(self, perm_ctx: PermCtx) -> Optional[str]:
+        """从 ctx 中获取当前资源关联的父级资源的 id"""

--- a/bcs-app/backend/iam/permissions/request.py
+++ b/bcs-app/backend/iam/permissions/request.py
@@ -52,6 +52,6 @@ class ActionResourcesRequest:
     note: resources 是由资源 ID 构成的列表. 为 None 时，表示资源无关.
     """
 
-    resource_type: str
     action_id: str
+    resource_type: str
     resources: Optional[List[str]] = None

--- a/bcs-app/backend/iam/permissions/request.py
+++ b/bcs-app/backend/iam/permissions/request.py
@@ -53,5 +53,5 @@ class ActionResourcesRequest:
     """
 
     action_id: str
-    resource_type: str
+    resource_type: Optional[str] = None
     resources: Optional[List[str]] = None

--- a/bcs-app/backend/iam/permissions/resources/cluster.py
+++ b/bcs-app/backend/iam/permissions/resources/cluster.py
@@ -12,11 +12,10 @@
 # specific language governing permissions and limitations under the License.
 #
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Type
+from typing import Dict, Optional, Type
 
 from backend.iam.permissions import decorators
 from backend.iam.permissions.perm import PermCtx, Permission, ResourceRequest
-from backend.iam.permissions.request import ActionResourcesRequest
 from backend.packages.blue_krill.data_types.enum import EnumField, StructuredEnum
 
 from .project import ProjectPermission, related_project_perm
@@ -61,15 +60,6 @@ class related_cluster_perm(decorators.RelatedPermission):
         else:
             raise TypeError('missing ClusterPermCtx instance argument')
 
-    def _action_request_list(self, perm_ctx: ClusterPermCtx) -> List[ActionResourcesRequest]:
-        """"""
-        resources = [perm_ctx.cluster_id] if perm_ctx.cluster_id else None
-        return [
-            ActionResourcesRequest(
-                resource_type=self.perm_obj.resource_type, action_id=self.action_id, resources=resources
-            )
-        ]
-
 
 class cluster_perm(decorators.Permission):
     module_name: str = ClusterType
@@ -80,7 +70,7 @@ class ClusterPermission(Permission):
 
     resource_type: str = ClusterType
     resource_request_cls: Type[ResourceRequest] = ClusterRequest
-    parent_perm_obj = ProjectPermission()
+    parent_res_perm = ProjectPermission()
 
     @related_project_perm(method_name='can_view')
     def can_create(self, perm_ctx: ClusterPermCtx, raise_exception: bool = True) -> bool:

--- a/bcs-app/backend/iam/permissions/resources/cluster.py
+++ b/bcs-app/backend/iam/permissions/resources/cluster.py
@@ -18,9 +18,8 @@ from backend.iam.permissions import decorators
 from backend.iam.permissions.perm import PermCtx, Permission, ResourceRequest
 from backend.packages.blue_krill.data_types.enum import EnumField, StructuredEnum
 
+from .constants import ResourceType
 from .project import ProjectPermission, related_project_perm
-
-ClusterType = 'cluster'
 
 
 class ClusterAction(str, StructuredEnum):
@@ -37,7 +36,7 @@ class ClusterPermCtx(PermCtx):
 
 
 class ClusterRequest(ResourceRequest):
-    resource_type: str = ClusterType
+    resource_type: str = ResourceType.Cluster
     attr = {'_bk_iam_path_': f'/project,{{project_id}}/'}
 
     def _make_attribute(self, res_id: str) -> Dict:
@@ -47,7 +46,7 @@ class ClusterRequest(ResourceRequest):
 
 class related_cluster_perm(decorators.RelatedPermission):
 
-    module_name: str = ClusterType
+    module_name: str = ResourceType.Cluster
 
     def _convert_perm_ctx(self, instance, args, kwargs) -> PermCtx:
         """仅支持第一个参数是 PermCtx 子类实例"""
@@ -62,13 +61,13 @@ class related_cluster_perm(decorators.RelatedPermission):
 
 
 class cluster_perm(decorators.Permission):
-    module_name: str = ClusterType
+    module_name: str = ResourceType.Cluster
 
 
 class ClusterPermission(Permission):
     """集群权限"""
 
-    resource_type: str = ClusterType
+    resource_type: str = ResourceType.Cluster
     resource_request_cls: Type[ResourceRequest] = ClusterRequest
     parent_res_perm = ProjectPermission()
 

--- a/bcs-app/backend/iam/permissions/resources/constants.py
+++ b/bcs-app/backend/iam/permissions/resources/constants.py
@@ -10,8 +10,11 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from .cluster import ClusterRequest
-from .constants import ResourceType
-from .namespace import NamespaceRequest
-from .project import ProjectRequest
-from .templateset import TemplatesetRequest
+from backend.packages.blue_krill.data_types.enum import StructuredEnum
+
+
+class ResourceType(str, StructuredEnum):
+    Project = 'project'
+    Cluster = 'cluster'
+    Namespace = 'namespace'
+    Templateset = "templateset"

--- a/bcs-app/backend/iam/permissions/resources/namespace.py
+++ b/bcs-app/backend/iam/permissions/resources/namespace.py
@@ -18,10 +18,25 @@ from backend.iam.permissions import decorators
 from backend.iam.permissions.perm import PermCtx, Permission
 from backend.iam.permissions.request import ResourceRequest
 from backend.packages.blue_krill.data_types.enum import EnumField, StructuredEnum
+from backend.utils.basic import md5
 
 from .cluster import ClusterPermission, related_cluster_perm
+from .constants import ResourceType
 
-NamespaceType = 'namespace'
+
+def compress_cluster_ns_id(cluster_ns_id: Optional[str]) -> Optional[str]:
+    """超过32位长度后，通过摘要算法压缩至32位长度"""
+    if not cluster_ns_id:
+        return cluster_ns_id
+
+    # 去除集群前缀 BCS-K8S-
+    if cluster_ns_id.startswith('BCS-K8S-'):
+        cluster_ns_id = cluster_ns_id[8:]
+
+    if len(cluster_ns_id) <= 32:
+        return cluster_ns_id
+
+    return md5(cluster_ns_id)
 
 
 class NamespaceAction(str, StructuredEnum):
@@ -38,9 +53,13 @@ class NamespacePermCtx(PermCtx):
     cluster_id: str = ''
     cluster_ns_id: Optional[str] = None
 
+    def __post_init__(self):
+        """权限中心的 resource_id 长度限制为32位"""
+        self.cluster_ns_id = compress_cluster_ns_id(self.cluster_ns_id)
+
 
 class NamespaceRequest(ResourceRequest):
-    resource_type: str = NamespaceType
+    resource_type: str = ResourceType.Namespace
     attr = {'_bk_iam_path_': f'/project,{{project_id}}/cluster,{{cluster_id}}/'}
 
     def _make_attribute(self, res_id: str) -> Dict:
@@ -52,7 +71,7 @@ class NamespaceRequest(ResourceRequest):
 
 class related_namespace_perm(decorators.RelatedPermission):
 
-    module_name: str = NamespaceType
+    module_name: str = ResourceType.Namespace
 
     def _convert_perm_ctx(self, instance, args, kwargs) -> PermCtx:
         """仅支持第一个参数是 PermCtx 子类实例"""
@@ -70,13 +89,13 @@ class related_namespace_perm(decorators.RelatedPermission):
 
 
 class namespace_perm(decorators.Permission):
-    module_name: str = NamespaceType
+    module_name: str = ResourceType.Namespace
 
 
 class NamespacePermission(Permission):
     """命名空间权限"""
 
-    resource_type: str = NamespaceType
+    resource_type: str = ResourceType.Namespace
     resource_request_cls: Type[ResourceRequest] = NamespaceRequest
     parent_res_perm = ClusterPermission()
 

--- a/bcs-app/backend/iam/permissions/resources/namespace.py
+++ b/bcs-app/backend/iam/permissions/resources/namespace.py
@@ -12,11 +12,11 @@
 # specific language governing permissions and limitations under the License.
 #
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Type
+from typing import Dict, Optional, Type
 
 from backend.iam.permissions import decorators
 from backend.iam.permissions.perm import PermCtx, Permission
-from backend.iam.permissions.request import ActionResourcesRequest, ResourceRequest
+from backend.iam.permissions.request import ResourceRequest
 from backend.packages.blue_krill.data_types.enum import EnumField, StructuredEnum
 
 from .cluster import ClusterPermission, related_cluster_perm
@@ -68,15 +68,6 @@ class related_namespace_perm(decorators.RelatedPermission):
         else:
             raise TypeError('missing NamespacePermCtx instance argument')
 
-    def _action_request_list(self, perm_ctx: NamespacePermCtx) -> List[ActionResourcesRequest]:
-        """"""
-        resources = [perm_ctx.cluster_ns_id] if perm_ctx.cluster_ns_id else None
-        return [
-            ActionResourcesRequest(
-                resource_type=self.perm_obj.resource_type, action_id=self.action_id, resources=resources
-            )
-        ]
-
 
 class namespace_perm(decorators.Permission):
     module_name: str = NamespaceType
@@ -87,7 +78,7 @@ class NamespacePermission(Permission):
 
     resource_type: str = NamespaceType
     resource_request_cls: Type[ResourceRequest] = NamespaceRequest
-    parent_perm_obj = ClusterPermission()
+    parent_res_perm = ClusterPermission()
 
     @related_cluster_perm(method_name='can_view')
     def can_create(self, perm_ctx: NamespacePermCtx, raise_exception: bool = True) -> bool:

--- a/bcs-app/backend/iam/permissions/resources/project.py
+++ b/bcs-app/backend/iam/permissions/resources/project.py
@@ -18,7 +18,7 @@ from backend.iam.permissions import decorators
 from backend.iam.permissions.perm import ActionResourcesRequest, PermCtx, Permission, ResourceRequest
 from backend.packages.blue_krill.data_types.enum import EnumField, StructuredEnum
 
-ResourceType = 'project'
+ProjectType = 'project'
 
 
 class ProjectAction(str, StructuredEnum):
@@ -28,7 +28,7 @@ class ProjectAction(str, StructuredEnum):
 
 
 class ProjectRequest(ResourceRequest):
-    resource_type: str = ResourceType
+    resource_type: str = ProjectType
 
 
 @dataclass
@@ -39,7 +39,7 @@ class ProjectPermCtx(PermCtx):
 class ProjectPermission(Permission):
     """项目权限"""
 
-    resource_type: str = ResourceType
+    resource_type: str = ProjectType
     resource_request_cls: Type[ResourceRequest] = ProjectRequest
 
     def can_create(self, perm_ctx: ProjectPermCtx, raise_exception: bool = True) -> bool:
@@ -51,13 +51,16 @@ class ProjectPermission(Permission):
     def can_edit(self, perm_ctx: ProjectPermCtx, raise_exception: bool = True) -> bool:
         return self.can_action(perm_ctx, ProjectAction.EDIT, raise_exception)
 
-    def _get_resource_id_from_ctx(self, perm_ctx: ProjectPermCtx) -> Optional[str]:
+    def _get_resource_id(self, perm_ctx: ProjectPermCtx) -> Optional[str]:
         return perm_ctx.project_id
+
+    def _get_parent_resource_id(self, perm_ctx: ProjectPermCtx) -> Optional[str]:
+        return None
 
 
 class related_project_perm(decorators.RelatedPermission):
 
-    module_name: str = ResourceType
+    module_name: str = ProjectType
 
     def _convert_perm_ctx(self, instance, args, kwargs) -> PermCtx:
         """仅支持第一个参数是 PermCtx 子类实例"""

--- a/bcs-app/backend/iam/permissions/resources/project.py
+++ b/bcs-app/backend/iam/permissions/resources/project.py
@@ -18,7 +18,7 @@ from backend.iam.permissions import decorators
 from backend.iam.permissions.perm import PermCtx, Permission, ResourceRequest
 from backend.packages.blue_krill.data_types.enum import EnumField, StructuredEnum
 
-ProjectType = 'project'
+from .constants import ResourceType
 
 
 class ProjectAction(str, StructuredEnum):
@@ -28,7 +28,7 @@ class ProjectAction(str, StructuredEnum):
 
 
 class ProjectRequest(ResourceRequest):
-    resource_type: str = ProjectType
+    resource_type: str = ResourceType.Project
 
 
 @dataclass
@@ -39,7 +39,7 @@ class ProjectPermCtx(PermCtx):
 class ProjectPermission(Permission):
     """项目权限"""
 
-    resource_type: str = ProjectType
+    resource_type: str = ResourceType.Project
     resource_request_cls: Type[ResourceRequest] = ProjectRequest
 
     def can_create(self, perm_ctx: ProjectPermCtx, raise_exception: bool = True) -> bool:
@@ -60,7 +60,7 @@ class ProjectPermission(Permission):
 
 class related_project_perm(decorators.RelatedPermission):
 
-    module_name: str = ProjectType
+    module_name: str = ResourceType.Project
 
     def _convert_perm_ctx(self, instance, args, kwargs) -> PermCtx:
         """仅支持第一个参数是 PermCtx 子类实例"""

--- a/bcs-app/backend/iam/permissions/resources/project.py
+++ b/bcs-app/backend/iam/permissions/resources/project.py
@@ -12,10 +12,10 @@
 # specific language governing permissions and limitations under the License.
 #
 from dataclasses import dataclass
-from typing import List, Optional, Type
+from typing import Optional, Type
 
 from backend.iam.permissions import decorators
-from backend.iam.permissions.perm import ActionResourcesRequest, PermCtx, Permission, ResourceRequest
+from backend.iam.permissions.perm import PermCtx, Permission, ResourceRequest
 from backend.packages.blue_krill.data_types.enum import EnumField, StructuredEnum
 
 ProjectType = 'project'
@@ -70,12 +70,3 @@ class related_project_perm(decorators.RelatedPermission):
             return ProjectPermCtx(username=args[0].username, project_id=args[0].project_id)
         else:
             raise TypeError('missing ProjectPermCtx instance argument')
-
-    def _action_request_list(self, perm_ctx: ProjectPermCtx) -> List[ActionResourcesRequest]:
-        """"""
-        resources = [perm_ctx.project_id] if perm_ctx.project_id else None
-        return [
-            ActionResourcesRequest(
-                resource_type=self.perm_obj.resource_type, action_id=self.action_id, resources=resources
-            )
-        ]

--- a/bcs-app/backend/iam/permissions/resources/templateset.py
+++ b/bcs-app/backend/iam/permissions/resources/templateset.py
@@ -12,11 +12,11 @@
 # specific language governing permissions and limitations under the License.
 #
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Type
+from typing import Dict, Optional, Type
 
 from backend.iam.permissions import decorators
 from backend.iam.permissions.perm import PermCtx, Permission
-from backend.iam.permissions.request import ActionResourcesRequest, ResourceRequest
+from backend.iam.permissions.request import ResourceRequest
 from backend.packages.blue_krill.data_types.enum import EnumField, StructuredEnum
 
 from .project import ProjectPermission, related_project_perm
@@ -61,15 +61,6 @@ class related_templateset_perm(decorators.RelatedPermission):
         else:
             raise TypeError('missing TemplatesetPermCtx instance argument')
 
-    def _action_request_list(self, perm_ctx: TemplatesetPermCtx) -> List[ActionResourcesRequest]:
-        """"""
-        resources = [perm_ctx.template_id] if perm_ctx.template_id else None
-        return [
-            ActionResourcesRequest(
-                resource_type=self.perm_obj.resource_type, action_id=self.action_id, resources=resources
-            )
-        ]
-
 
 class templateset_perm(decorators.Permission):
     module_name: str = TemplatesetType
@@ -80,7 +71,7 @@ class TemplatesetPermission(Permission):
 
     resource_type: str = TemplatesetType
     resource_request_cls: Type[ResourceRequest] = TemplatesetRequest
-    parent_perm_obj = ProjectPermission()
+    parent_res_perm = ProjectPermission()
 
     @related_project_perm(method_name="can_view")
     def can_create(self, perm_ctx: TemplatesetPermCtx, raise_exception: bool = True) -> bool:

--- a/bcs-app/backend/iam/permissions/resources/templateset.py
+++ b/bcs-app/backend/iam/permissions/resources/templateset.py
@@ -19,9 +19,8 @@ from backend.iam.permissions.perm import PermCtx, Permission
 from backend.iam.permissions.request import ResourceRequest
 from backend.packages.blue_krill.data_types.enum import EnumField, StructuredEnum
 
+from .constants import ResourceType
 from .project import ProjectPermission, related_project_perm
-
-TemplatesetType = "templateset"
 
 
 class TemplatesetAction(str, StructuredEnum):
@@ -39,7 +38,7 @@ class TemplatesetPermCtx(PermCtx):
 
 
 class TemplatesetRequest(ResourceRequest):
-    resource_type: str = TemplatesetType
+    resource_type: str = ResourceType.Templateset
     attr = {'_bk_iam_path_': f'/project,{{project_id}}/'}
 
     def _make_attribute(self, res_id: str) -> Dict:
@@ -48,7 +47,7 @@ class TemplatesetRequest(ResourceRequest):
 
 
 class related_templateset_perm(decorators.RelatedPermission):
-    module_name: str = TemplatesetType
+    module_name: str = ResourceType.Templateset
 
     def _convert_perm_ctx(self, instance, args, kwargs) -> PermCtx:
         """仅支持第一个参数是 PermCtx 子类实例"""
@@ -63,13 +62,13 @@ class related_templateset_perm(decorators.RelatedPermission):
 
 
 class templateset_perm(decorators.Permission):
-    module_name: str = TemplatesetType
+    module_name: str = ResourceType.Templateset
 
 
 class TemplatesetPermission(Permission):
     """模板集权限"""
 
-    resource_type: str = TemplatesetType
+    resource_type: str = ResourceType.Templateset
     resource_request_cls: Type[ResourceRequest] = TemplatesetRequest
     parent_res_perm = ProjectPermission()
 

--- a/bcs-app/backend/iam/permissions/resources/templateset.py
+++ b/bcs-app/backend/iam/permissions/resources/templateset.py
@@ -17,10 +17,11 @@ from typing import Dict, List, Optional, Type
 from backend.iam.permissions import decorators
 from backend.iam.permissions.perm import PermCtx, Permission
 from backend.iam.permissions.request import ActionResourcesRequest, ResourceRequest
-from backend.iam.permissions.resources.project import related_project_perm
 from backend.packages.blue_krill.data_types.enum import EnumField, StructuredEnum
 
-ResourceType = "templateset"
+from .project import ProjectPermission, related_project_perm
+
+TemplatesetType = "templateset"
 
 
 class TemplatesetAction(str, StructuredEnum):
@@ -38,7 +39,7 @@ class TemplatesetPermCtx(PermCtx):
 
 
 class TemplatesetRequest(ResourceRequest):
-    resource_type: str = ResourceType
+    resource_type: str = TemplatesetType
     attr = {'_bk_iam_path_': f'/project,{{project_id}}/'}
 
     def _make_attribute(self, res_id: str) -> Dict:
@@ -47,7 +48,7 @@ class TemplatesetRequest(ResourceRequest):
 
 
 class related_templateset_perm(decorators.RelatedPermission):
-    module_name: str = ResourceType
+    module_name: str = TemplatesetType
 
     def _convert_perm_ctx(self, instance, args, kwargs) -> PermCtx:
         """仅支持第一个参数是 PermCtx 子类实例"""
@@ -71,14 +72,15 @@ class related_templateset_perm(decorators.RelatedPermission):
 
 
 class templateset_perm(decorators.Permission):
-    module_name: str = ResourceType
+    module_name: str = TemplatesetType
 
 
 class TemplatesetPermission(Permission):
     """模板集权限"""
 
-    resource_type: str = ResourceType
+    resource_type: str = TemplatesetType
     resource_request_cls: Type[ResourceRequest] = TemplatesetRequest
+    parent_perm_obj = ProjectPermission()
 
     @related_project_perm(method_name="can_view")
     def can_create(self, perm_ctx: TemplatesetPermCtx, raise_exception: bool = True) -> bool:
@@ -100,8 +102,11 @@ class TemplatesetPermission(Permission):
     def can_instantiate(self, perm_ctx: TemplatesetPermCtx, raise_exception: bool = True) -> bool:
         return self.can_action(perm_ctx, TemplatesetAction.INSTANTIATE, raise_exception)
 
-    def _make_res_request(self, res_id: str, perm_ctx: TemplatesetPermCtx) -> ResourceRequest:
+    def make_res_request(self, res_id: str, perm_ctx: TemplatesetPermCtx) -> ResourceRequest:
         return self.resource_request_cls(res_id, project_id=perm_ctx.project_id)
 
-    def _get_resource_id_from_ctx(self, perm_ctx: TemplatesetPermCtx) -> Optional[str]:
+    def _get_resource_id(self, perm_ctx: TemplatesetPermCtx) -> Optional[str]:
         return perm_ctx.template_id
+
+    def _get_parent_resource_id(self, perm_ctx: TemplatesetPermCtx) -> Optional[str]:
+        return perm_ctx.project_id

--- a/bcs-app/backend/iam/request_maker.py
+++ b/bcs-app/backend/iam/request_maker.py
@@ -10,8 +10,19 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from .cluster import ClusterRequest
-from .constants import ResourceType
-from .namespace import NamespaceRequest
-from .project import ProjectRequest
-from .templateset import TemplatesetRequest
+
+from .permissions import resources
+from .permissions.request import ResourceRequest
+
+ResourceType = resources.ResourceType
+
+ResourceRequestMap = {
+    ResourceType.Project: resources.ProjectRequest,
+    ResourceType.Cluster: resources.ClusterRequest,
+    ResourceType.Namespace: resources.NamespaceRequest,
+    ResourceType.Templateset: resources.TemplatesetRequest,
+}
+
+
+def make_res_request(res_type: str, res_id: str, **attr_kwargs) -> ResourceRequest:
+    return ResourceRequestMap[res_type](res_id, **attr_kwargs)

--- a/bcs-app/backend/iam/serializers.py
+++ b/bcs-app/backend/iam/serializers.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017-2021 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
+
+from .permissions.resources.constants import ResourceType
+
+
+class ResourceRequestSLZ(serializers.Serializer):
+    resource_type = serializers.ChoiceField(choices=ResourceType.get_choices(), required=False)
+    resource_id = serializers.CharField(required=False)
+    iam_path_attrs = serializers.JSONField(default=dict)
+
+    def validate(self, data):
+        if 'resource_type' in data and 'resource_id' not in data:
+            raise ValidationError('missing param resource_id')
+        return data
+
+
+class ResourceActionSLZ(ResourceRequestSLZ):
+    action_id = serializers.CharField()
+
+
+class ResourceMultiActionsSLZ(ResourceRequestSLZ):
+    action_ids = serializers.ListField(child=serializers.CharField(), min_length=1)

--- a/bcs-app/backend/iam/urls.py
+++ b/bcs-app/backend/iam/urls.py
@@ -10,8 +10,14 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from .cluster import ClusterRequest
-from .constants import ResourceType
-from .namespace import NamespaceRequest
-from .project import ProjectRequest
-from .templateset import TemplatesetRequest
+from django.conf.urls import url
+
+from . import views
+
+urlpatterns = [
+    url(r'^user_perms/$', views.UserPermsViewSet.as_view({'post': 'get_perms'})),
+    url(
+        r'^user_perms/actions/(?P<action_id>[\w]+)/$',
+        views.UserPermsViewSet.as_view({'post': 'get_perm_by_action_id'}),
+    ),
+]

--- a/bcs-app/backend/iam/views.py
+++ b/bcs-app/backend/iam/views.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017-2021 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from rest_framework.response import Response
+
+from backend.bcs_web import viewsets
+
+from .permissions.apply_url import ApplyURLGenerator
+from .permissions.client import IAMClient
+from .permissions.request import ActionResourcesRequest
+from .request_maker import make_res_request
+from .serializers import ResourceActionSLZ, ResourceMultiActionsSLZ
+
+
+class UserPermsViewSet(viewsets.SystemViewSet):
+    def get_perms(self, request):
+        """查询多个 action_id 的权限"""
+        validated_data = self.params_validate(ResourceMultiActionsSLZ)
+
+        client = IAMClient()
+
+        resource_type = validated_data.get('resource_type')
+        if not resource_type:  # 资源实例无关
+            perms = client.resource_type_multi_actions_allowed(request.user.username, validated_data['action_ids'])
+            return Response({'perms': perms})
+
+        # 资源实例相关
+        res_request = make_res_request(
+            resource_type, validated_data['resource_id'], **validated_data['iam_path_attrs']
+        )
+        perms = client.resource_inst_multi_actions_allowed(
+            request.user.username, validated_data['action_ids'], res_request
+        )
+        return Response({'perms': perms})
+
+    def get_perm_by_action_id(self, request, action_id):
+        """查询指定 action_id 的权限"""
+        validated_data = self.params_validate(ResourceActionSLZ, action_id=action_id)
+
+        client = IAMClient()
+
+        resource_type = validated_data.get('resource_type')
+        if resource_type:  # 资源实例相关
+            res_request = make_res_request(
+                resource_type, validated_data['resource_id'], **validated_data['iam_path_attrs']
+            )
+            is_allowed = client.resource_inst_allowed(request.user.username, action_id, res_request)
+        else:  # 资源实例无关
+            is_allowed = client.resource_type_allowed(request.user.username, action_id)
+
+        perms = {action_id: is_allowed}
+        # 无权限时，带上权限申请跳转链接
+        if not is_allowed:
+            perms['apply_url'] = ApplyURLGenerator.generate_apply_url(
+                request.user.username,
+                action_request_list=[
+                    ActionResourcesRequest(
+                        action_id=action_id,
+                        resource_type=resource_type,
+                        resources=[validated_data['resource_id']] if resource_type else None,
+                    )
+                ],
+            )
+
+        return Response({'perms': perms})

--- a/bcs-app/backend/iam/views.py
+++ b/bcs-app/backend/iam/views.py
@@ -10,6 +10,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+from rest_framework import permissions
 from rest_framework.response import Response
 
 from backend.bcs_web import viewsets
@@ -22,6 +23,8 @@ from .serializers import ResourceActionSLZ, ResourceMultiActionsSLZ
 
 
 class UserPermsViewSet(viewsets.SystemViewSet):
+    permission_classes = (permissions.IsAuthenticated,)
+
     def get_perms(self, request):
         """查询多个 action_id 的权限"""
         validated_data = self.params_validate(ResourceMultiActionsSLZ)

--- a/bcs-app/backend/tests/iam/conftest.py
+++ b/bcs-app/backend/tests/iam/conftest.py
@@ -19,6 +19,8 @@ import pytest
 from backend.iam.permissions.apply_url import ApplyURLGenerator
 from backend.iam.permissions.perm import ActionResourcesRequest
 
+from .fake_iam import FakeIAMClient
+
 
 def generate_apply_url(username: str, action_request_list: List[ActionResourcesRequest]) -> List[str]:
     expect = []

--- a/bcs-app/backend/tests/iam/conftest.py
+++ b/bcs-app/backend/tests/iam/conftest.py
@@ -10,17 +10,28 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+#
+from typing import List
+from unittest import mock
+
 import pytest
 
-from backend.tests.testing_utils.base import generate_random_string
+from backend.iam.permissions.apply_url import ApplyURLGenerator
+from backend.iam.permissions.perm import ActionResourcesRequest
 
 
-@pytest.fixture
-def cluster_ns_id():
-    return f'BCS-K8S-{generate_random_string(16)}'
+def generate_apply_url(username: str, action_request_list: List[ActionResourcesRequest]) -> List[str]:
+    expect = []
+    for req in action_request_list:
+        suffix = ''
+        if req.resources:
+            suffix = ''.join(req.resources)
+        expect.append(f'{req.resource_type}:{req.action_id}:{suffix}')
+
+    return expect
 
 
-@pytest.fixture
-def template_id():
-    """生成一个随机模板集 ID"""
-    return generate_random_string(32)
+@pytest.fixture(autouse=True)
+def patch_generate_apply_url():
+    with mock.patch.object(ApplyURLGenerator, 'generate_apply_url', new=generate_apply_url):
+        yield

--- a/bcs-app/backend/tests/iam/fake_iam.py
+++ b/bcs-app/backend/tests/iam/fake_iam.py
@@ -11,9 +11,13 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 #
-from iam import Request
+from typing import Dict, List
+
+from django.conf import settings
+from iam import Action, MultiActionRequest, Request, Subject
 
 from backend.iam.permissions.perm import Permission
+from backend.iam.permissions.request import ResourceRequest
 
 from .permissions import roles
 
@@ -99,3 +103,36 @@ class FakeTemplatesetIAM:
 
 class FakeTemplatesetPermission(Permission):
     iam = FakeTemplatesetIAM()
+
+
+class FakeIAMClient:
+    def resource_type_allowed(self, username: str, action_id: str, use_cache: bool = False) -> bool:
+        if action_id == 'project_create':
+            return True
+        return False
+
+    def resource_inst_allowed(
+        self, username: str, action_id: str, res_request: ResourceRequest, use_cache: bool = False
+    ) -> bool:
+        if action_id in ['cluster_create', 'cluster_view']:
+            return True
+        return False
+
+    def resource_type_multi_actions_allowed(self, username: str, action_ids: List[str]) -> Dict[str, bool]:
+        return {action_id: self.resource_type_allowed(username, action_id) for action_id in action_ids}
+
+    def resource_inst_multi_actions_allowed(
+        self, username: str, action_ids: List[str], res_request: ResourceRequest
+    ) -> Dict[str, bool]:
+        multi = {}
+        for action in action_ids:
+            is_allowed = False
+            if action in ['cluster_create', 'cluster_view']:
+                is_allowed = True
+            multi[action] = is_allowed
+        return multi
+
+    def batch_resource_multi_actions_allowed(
+        self, username: str, action_ids: List[str], res_request: ResourceRequest
+    ) -> Dict[str, Dict[str, bool]]:
+        return {}

--- a/bcs-app/backend/tests/iam/fake_iam.py
+++ b/bcs-app/backend/tests/iam/fake_iam.py
@@ -135,4 +135,17 @@ class FakeIAMClient:
     def batch_resource_multi_actions_allowed(
         self, username: str, action_ids: List[str], res_request: ResourceRequest
     ) -> Dict[str, Dict[str, bool]]:
-        return {}
+        res = res_request.res
+        if isinstance(res, str):
+            res = [res]
+
+        perms = {}
+
+        for indx, r_id in enumerate(res):
+            if indx % 2 == 0:
+                p = {action_id: False for action_id in action_ids}
+            else:
+                p = {action_id: True for action_id in action_ids}
+            perms[r_id] = p
+
+        return perms

--- a/bcs-app/backend/tests/iam/permissions/conftest.py
+++ b/bcs-app/backend/tests/iam/permissions/conftest.py
@@ -38,7 +38,7 @@ def generate_apply_url(username: str, action_request_list: List[ActionResourcesR
         suffix = ''
         if req.resources:
             suffix = ''.join(req.resources)
-        expect.append(f'{req.resource_type}{req.action_id}{suffix}')
+        expect.append(f'{req.resource_type}:{req.action_id}:{suffix}')
 
     return expect
 

--- a/bcs-app/backend/tests/iam/permissions/test_cluster.py
+++ b/bcs-app/backend/tests/iam/permissions/test_cluster.py
@@ -45,6 +45,24 @@ class TestClusterPermission:
         perm_ctx = ClusterPermCtx(username=roles.ADMIN_USER, project_id=project_id)
         assert cluster_permission_obj.can_create(perm_ctx)
 
+    def test_can_not_create(self, cluster_permission_obj, project_id, cluster_id):
+        perm_ctx = ClusterPermCtx(username=roles.ANONYMOUS_USER, project_id=project_id)
+        with pytest.raises(PermissionDeniedError) as exec:
+            cluster_permission_obj.can_create(perm_ctx)
+        assert exec.value.data['apply_url'] == generate_apply_url(
+            roles.ANONYMOUS_USER,
+            [
+                ActionResourcesRequest(
+                    resource_type=ProjectPermission.resource_type,
+                    action_id=ClusterAction.CREATE,
+                    resources=[project_id],
+                ),
+                ActionResourcesRequest(
+                    resource_type=ProjectPermission.resource_type, action_id=ProjectAction.VIEW, resources=[project_id]
+                ),
+            ],
+        )
+
     def test_can_view(self, cluster_permission_obj, project_id, cluster_id):
         perm_ctx = ClusterPermCtx(username=roles.ADMIN_USER, project_id=project_id, cluster_id=cluster_id)
         assert cluster_permission_obj.can_view(perm_ctx)
@@ -82,7 +100,9 @@ class TestClusterPermission:
             cluster_id,
             expected_action_list=[
                 ActionResourcesRequest(
-                    resource_type=ProjectPermission.resource_type, action_id=ProjectAction.VIEW, resources=[project_id]
+                    resource_type=ProjectPermission.resource_type,
+                    action_id=ProjectAction.VIEW,
+                    resources=[project_id],
                 )
             ],
         )
@@ -101,7 +121,9 @@ class TestClusterPermission:
                     resources=[cluster_id],
                 ),
                 ActionResourcesRequest(
-                    resource_type=ProjectPermission.resource_type, action_id=ProjectAction.VIEW, resources=[project_id]
+                    resource_type=ProjectPermission.resource_type,
+                    action_id=ProjectAction.VIEW,
+                    resources=[project_id],
                 ),
             ],
         )

--- a/bcs-app/backend/tests/iam/permissions/test_cluster.py
+++ b/bcs-app/backend/tests/iam/permissions/test_cluster.py
@@ -19,10 +19,10 @@ from backend.iam.permissions.exceptions import PermissionDeniedError
 from backend.iam.permissions.request import ActionResourcesRequest
 from backend.iam.permissions.resources.cluster import ClusterAction, ClusterPermCtx, ClusterPermission, cluster_perm
 from backend.iam.permissions.resources.project import ProjectAction, ProjectPermission
+from backend.tests.iam.conftest import generate_apply_url
 
 from ..fake_iam import FakeClusterPermission, FakeProjectPermission
 from . import roles
-from .conftest import generate_apply_url
 
 
 @pytest.fixture

--- a/bcs-app/backend/tests/iam/permissions/test_decorators.py
+++ b/bcs-app/backend/tests/iam/permissions/test_decorators.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+#
+# Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community Edition) available.
+# Copyright (C) 2017-2019 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+from unittest import mock
+
+import pytest
+from django.conf.urls import url
+from rest_framework import permissions
+
+from backend.bcs_web import viewsets
+from backend.iam.permissions.decorators import response_perms
+from backend.iam.permissions.resources.cluster import ClusterRequest
+from backend.utils.response import BKAPIResponse
+
+from ..fake_iam import FakeIAMClient
+
+pytestmark = pytest.mark.django_db
+
+cluster_data = [{'cluster_id': 'BCS-K8S-40000', 'name': "测试集群"}, {'cluster_id': 'BCS-K8S-40001', 'name': "演示集群"}]
+
+
+@pytest.fixture(autouse=True)
+def patch_iam_client():
+    with mock.patch('backend.iam.permissions.decorators.IAMClient', new=FakeIAMClient):
+        yield
+
+
+class ClusterViewset(viewsets.SystemViewSet):
+    permission_classes = (permissions.IsAuthenticated,)
+
+    @response_perms(
+        action_id_list=['cluster_view', 'cluster_manage'], res_request_cls=ClusterRequest, resource_id_key='cluster_id'
+    )
+    def get_clusters(self, request):
+        request.iam_path_attrs = {'project_id': 'test1234567'}
+        return BKAPIResponse(cluster_data)
+
+
+urlpatterns = [
+    url('clusters/', ClusterViewset.as_view({'get': 'get_clusters'})),
+]
+
+
+@pytest.mark.urls(__name__)
+class TestResponsePerms:
+    def test_perms(self, api_client):
+        response = api_client.get('http://testserver/clusters/')
+        perms = response.json()['web_annotations']['perms']
+        assert perms['BCS-K8S-40000'] == {'cluster_view': False, 'cluster_manage': False}
+        assert perms['BCS-K8S-40001'] == {'cluster_view': True, 'cluster_manage': True}

--- a/bcs-app/backend/tests/iam/permissions/test_namespace.py
+++ b/bcs-app/backend/tests/iam/permissions/test_namespace.py
@@ -49,11 +49,22 @@ class TestNamespacePermission:
     note: 仅测试 namespace_use 这一代表性的权限，其他操作权限逻辑重复
     """
 
-    def test_can_use(self, namespace_permission_obj, project_id, cluster_id, cluster_ns_id):
-        perm_ctx = NamespacePermCtx(
-            username=roles.ADMIN_USER, project_id=project_id, cluster_id=cluster_id, cluster_ns_id=cluster_ns_id
+    def test_can_not_create_cluster_project(self, namespace_permission_obj, project_id, cluster_id):
+        username = roles.NAMESPACE_NO_CLUSTER_PROJECT_USER
+        perm_ctx = NamespacePermCtx(username=username, project_id=project_id, cluster_id=cluster_id)
+        with pytest.raises(PermissionDeniedError) as exec:
+            namespace_permission_obj.can_create(perm_ctx)
+        assert exec.value.data['apply_url'] == generate_apply_url(
+            username,
+            [
+                ActionResourcesRequest(
+                    resource_type=ClusterPermission.resource_type, action_id=ClusterAction.VIEW, resources=[cluster_id]
+                ),
+                ActionResourcesRequest(
+                    resource_type=ProjectPermission.resource_type, action_id=ProjectAction.VIEW, resources=[project_id]
+                ),
+            ],
         )
-        assert namespace_permission_obj.can_use(perm_ctx)
 
     def test_can_not_use(self, namespace_permission_obj, project_id, cluster_id, cluster_ns_id):
         username = roles.ANONYMOUS_USER
@@ -116,6 +127,30 @@ def helm_install(perm_ctx: NamespacePermCtx):
 
 
 class TestNamespacePermDecorator:
+    def test_can_not_create(self, namespace_permission_obj, project_id, cluster_id):
+        username = roles.ANONYMOUS_USER
+        perm_ctx = NamespacePermCtx(username=username, project_id=project_id, cluster_id=cluster_id)
+        with pytest.raises(PermissionDeniedError) as exec:
+            namespace_permission_obj.can_create(perm_ctx)
+        assert exec.value.data['apply_url'] == generate_apply_url(
+            username,
+            [
+                ActionResourcesRequest(
+                    resource_type=ClusterPermission.resource_type,
+                    action_id=NamespaceAction.CREATE,
+                    resources=[cluster_id],
+                ),
+                ActionResourcesRequest(
+                    resource_type=ClusterPermission.resource_type,
+                    action_id=ClusterAction.VIEW,
+                    resources=[cluster_id],
+                ),
+                ActionResourcesRequest(
+                    resource_type=ProjectPermission.resource_type, action_id=ProjectAction.VIEW, resources=[project_id]
+                ),
+            ],
+        )
+
     def test_can_use(self, namespace_permission_obj, project_id, cluster_id, cluster_ns_id):
         perm_ctx = NamespacePermCtx(
             username=roles.ADMIN_USER, project_id=project_id, cluster_id=cluster_id, cluster_ns_id=cluster_ns_id

--- a/bcs-app/backend/tests/iam/permissions/test_namespace.py
+++ b/bcs-app/backend/tests/iam/permissions/test_namespace.py
@@ -22,13 +22,14 @@ from backend.iam.permissions.resources.namespace import (
     NamespaceAction,
     NamespacePermCtx,
     NamespacePermission,
+    compress_cluster_ns_id,
     namespace_perm,
 )
 from backend.iam.permissions.resources.project import ProjectAction, ProjectPermission
+from backend.tests.iam.conftest import generate_apply_url
 
 from ..fake_iam import FakeClusterPermission, FakeNamespacePermission, FakeProjectPermission
 from . import roles
-from .conftest import generate_apply_url
 
 
 @pytest.fixture
@@ -79,12 +80,12 @@ class TestNamespacePermission:
                 ActionResourcesRequest(
                     resource_type=NamespacePermission.resource_type,
                     action_id=NamespaceAction.USE,
-                    resources=[cluster_ns_id],
+                    resources=[perm_ctx.cluster_ns_id],
                 ),
                 ActionResourcesRequest(
                     resource_type=NamespacePermission.resource_type,
                     action_id=NamespaceAction.VIEW,
-                    resources=[cluster_ns_id],
+                    resources=[perm_ctx.cluster_ns_id],
                 ),
                 ActionResourcesRequest(
                     resource_type=ClusterPermission.resource_type, action_id=ClusterAction.VIEW, resources=[cluster_id]
@@ -170,12 +171,12 @@ class TestNamespacePermDecorator:
                 ActionResourcesRequest(
                     resource_type=NamespacePermission.resource_type,
                     action_id=NamespaceAction.USE,
-                    resources=[cluster_ns_id],
+                    resources=[perm_ctx.cluster_ns_id],
                 ),
                 ActionResourcesRequest(
                     resource_type=NamespacePermission.resource_type,
                     action_id=NamespaceAction.VIEW,
-                    resources=[cluster_ns_id],
+                    resources=[perm_ctx.cluster_ns_id],
                 ),
                 ActionResourcesRequest(
                     resource_type=ClusterPermission.resource_type, action_id=ClusterAction.VIEW, resources=[cluster_id]
@@ -185,3 +186,14 @@ class TestNamespacePermDecorator:
                 ),
             ],
         )
+
+
+@pytest.mark.parametrize(
+    'cluster_namespace_id, expected',
+    [
+        ('BCS-K8S-40000:test-default', '40000:test-default'),
+        ('BCS-K8S-40000:' + 'abc' * 30, '95afa5b2fe10b65fc59c516a6f8cf1e7'),
+    ],
+)
+def test_compress_cluster_ns_id(cluster_namespace_id, expected):
+    assert compress_cluster_ns_id(cluster_namespace_id) == expected

--- a/bcs-app/backend/tests/iam/permissions/test_project.py
+++ b/bcs-app/backend/tests/iam/permissions/test_project.py
@@ -18,10 +18,10 @@ import pytest
 from backend.iam.permissions.exceptions import PermissionDeniedError
 from backend.iam.permissions.perm import ActionResourcesRequest
 from backend.iam.permissions.resources.project import ProjectAction, ProjectPermCtx, ProjectPermission
+from backend.tests.iam.conftest import generate_apply_url
 
 from ..fake_iam import FakeProjectPermission
 from . import roles
-from .conftest import generate_apply_url
 
 
 @pytest.fixture

--- a/bcs-app/backend/tests/iam/permissions/test_templateset.py
+++ b/bcs-app/backend/tests/iam/permissions/test_templateset.py
@@ -24,10 +24,10 @@ from backend.iam.permissions.resources.templateset import (
     TemplatesetPermission,
     templateset_perm,
 )
+from backend.tests.iam.conftest import generate_apply_url
 
 from ..fake_iam import FakeProjectPermission, FakeTemplatesetPermission
 from . import roles
-from .conftest import generate_apply_url
 
 
 @pytest.fixture

--- a/bcs-app/backend/tests/iam/test_views.py
+++ b/bcs-app/backend/tests/iam/test_views.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017-2021 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from unittest import mock
+
+import pytest
+
+from .fake_iam import FakeIAMClient
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def patch_iam_client():
+    with mock.patch('backend.iam.views.IAMClient', new=FakeIAMClient):
+        yield
+
+
+class TestUserPermsViewSet:
+    def test_get_perms_resource_type(self, api_client):
+        """资源实例无关"""
+        response = api_client.post(
+            f'/api/iam/user_perms/', data={'action_ids': ['project_create', 'bcs_project_create']}
+        )
+        perms = response.json()['data']['perms']
+        assert perms['project_create'] is True
+        assert perms['bcs_project_create'] is False
+
+    def test_get_perms_resource_inst(self, api_client, project_id, cluster_id):
+        """资源实例相关"""
+        data = {
+            'action_ids': ['cluster_view', 'namespace_create'],
+            'resource_type': 'cluster',
+            'resource_id': cluster_id,
+            'iam_path_attrs': {'project_id': project_id},
+        }
+        response = api_client.post(f'/api/iam/user_perms/', data)
+        perms = response.json()['data']['perms']
+        assert perms['cluster_view'] is True
+        assert perms['namespace_create'] is False
+
+    def test_get_perm_by_action_id_resource_type(self, api_client):
+        """资源实例无关"""
+        response = api_client.post(f'/api/iam/user_perms/actions/project_create/')
+        assert response.json()['data']['perms']['project_create'] is True
+
+        response = api_client.post(f'/api/iam/user_perms/actions/bcs_project_create/')
+        perms = response.json()['data']['perms']
+        assert perms['bcs_project_create'] is False
+        assert 'apply_url' in perms
+
+    def test_get_perm_by_action_id_resource_inst(self, api_client, project_id, cluster_id):
+        """资源实例相关"""
+        data = {
+            'resource_type': 'cluster',
+            'resource_id': cluster_id,
+            'iam_path_attrs': {'project_id': project_id},
+        }
+        response = api_client.post(f'/api/iam/user_perms/actions/namespace_create/', data=data)
+        perms = response.json()['data']['perms']
+        assert perms['namespace_create'] is False
+        assert 'apply_url' in perms

--- a/bcs-app/backend/tests/utils/test_basic.py
+++ b/bcs-app/backend/tests/utils/test_basic.py
@@ -13,7 +13,7 @@
 #
 import pytest
 
-from backend.utils.basic import get_with_placeholder, getitems, str2bool
+from backend.utils.basic import get_with_placeholder, getitems, md5, str2bool
 
 
 @pytest.mark.parametrize(
@@ -53,7 +53,7 @@ DICT_OBJ = {
 
 
 @pytest.mark.parametrize(
-    'items, expired, default',
+    'items, expected, default',
     [
         ('a', ['a1', 'a2', 'a3'], None),
         (['a'], ['a1', 'a2', 'a3'], None),
@@ -67,12 +67,12 @@ DICT_OBJ = {
         ('b.b4.b42', '--', '--'),
     ],
 )
-def test_getitems(items, expired, default):
-    assert getitems(DICT_OBJ, items, default) == expired
+def test_getitems(items, expected, default):
+    assert getitems(DICT_OBJ, items, default) == expected
 
 
 @pytest.mark.parametrize(
-    'items, expired',
+    'items, expected',
     [
         ('a', ['a1', 'a2', 'a3']),
         (['a'], ['a1', 'a2', 'a3']),
@@ -86,5 +86,16 @@ def test_getitems(items, expired, default):
         ('b.b4.b42', '--'),
     ],
 )
-def test_get_with_placeholder(items, expired):
-    assert get_with_placeholder(DICT_OBJ, items) == expired
+def test_get_with_placeholder(items, expected):
+    assert get_with_placeholder(DICT_OBJ, items) == expected
+
+
+@pytest.mark.parametrize(
+    'content, expected',
+    [
+        ('BCS-K8S-40000:test-default', '7f63b7f479c97c3c3a49863e974557ca'),
+        ('abc' * 30, 'daa54284568d250dde2cc8578c2e116a'),
+    ],
+)
+def test_md5(content, expected):
+    assert md5(content) == expected

--- a/bcs-app/backend/urls.py
+++ b/bcs-app/backend/urls.py
@@ -31,6 +31,7 @@ urlpatterns = [
             ("backend.container_service.projects.urls", "backend.container_service.projects"), namespace="projects"
         ),
     ),
+    url(r"^api/iam/", include("backend.iam.urls")),
     # 仓库管理
     url(r"^", include("backend.container_service.misc.depot.urls")),
     # 集群管理

--- a/bcs-app/backend/utils/basic.py
+++ b/bcs-app/backend/utils/basic.py
@@ -12,6 +12,7 @@
 # specific language governing permissions and limitations under the License.
 #
 import base64
+import hashlib
 import json
 import logging
 import re
@@ -162,3 +163,9 @@ def str2bool(source, default=False):
 def b64encode_json(data: Any) -> bytes:
     """返回base64.b64encode(bytes(json.dumps(data), 'utf-8'))"""
     return base64.b64encode(bytes(json.dumps(data), "utf-8"))
+
+
+def md5(content: str) -> str:
+    h = hashlib.md5()
+    h.update(content.encode("utf-8"))
+    return h.hexdigest()

--- a/bcs-app/backend/utils/views.py
+++ b/bcs-app/backend/utils/views.py
@@ -39,6 +39,7 @@ from backend.components.base import (
     CompResponseError,
 )
 from backend.dashboard.exceptions import DashboardBaseError
+from backend.iam.permissions.exceptions import PermissionDeniedError
 from backend.packages.blue_krill.web.std_error import APIError
 from backend.utils import exceptions as backend_exceptions
 from backend.utils.basic import str2bool
@@ -149,7 +150,7 @@ def custom_exception_handler(exc: Exception, context):
         data = {"code": 404, "message": _("资源未找到"), "data": None}
         set_rollback()
         return Response(data, status=200)
-    elif isinstance(exc, backend_exceptions.APIError):
+    elif isinstance(exc, (backend_exceptions.APIError, PermissionDeniedError)):
         data = {"code": exc.code, "message": "%s" % exc, "data": exc.data, "request_id": local.request_id}
         set_rollback()
         return Response(data, status=exc.status_code)


### PR DESCRIPTION
变更点(Changes)
- 实现`user_perms`接口，支持以 `action_id` 查询用户权限
- 实现`response_perms`装饰器，用于注入权限信息到返回数据的`web_annotations`中