### PR TITLE
minor: fix iamv3 migrate group

### DIFF
--- a/bcs-app/support-files/iam/0006_action_group.json
+++ b/bcs-app/support-files/iam/0006_action_group.json
@@ -36,7 +36,7 @@
                                     "id": "cluster_manage"
                                 },
                                 {
-                                    "id": "project_delete"
+                                    "id": "cluster_delete"
                                 }
                             ]
                         },


### PR DESCRIPTION
变更点(Changes)
修复migration时，`one action can only belong to one group fail`